### PR TITLE
Fixing Caliban integration & adding quill-caliban to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val sqlTestModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
 )
 
 lazy val dbModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
-  `quill-jdbc`, `quill-zio`, `quill-jdbc-zio`
+  `quill-jdbc`, `quill-zio`, `quill-jdbc-zio`, `quill-caliban`
 )
 
 lazy val jasyncModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
@@ -205,8 +205,8 @@ lazy val `quill-caliban` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.ghostdogpr" %% "caliban" % "1.2.0",
-        "com.github.ghostdogpr" %% "caliban-zio-http"   % "1.2.0",
+        "com.github.ghostdogpr" %% "caliban" % "1.2.4",
+        "com.github.ghostdogpr" %% "caliban-zio-http"   % "1.2.4",
         // Adding this to main dependencies would force users to use logback-classic for SLF4j unless the specifically remove it
         // seems to be safer to just exclude & add a commented about need for a SLF4j implementation in Docs.
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,

--- a/quill-caliban/src/main/scala/io/getquill/CalibanIntegration.scala
+++ b/quill-caliban/src/main/scala/io/getquill/CalibanIntegration.scala
@@ -5,16 +5,29 @@ import caliban.GraphQL.graphQL
 import caliban.introspection.adt.{ __InputValue, __Type, __TypeKind }
 import caliban.schema.{ ArgBuilder, Schema, Step }
 import caliban.{ InputValue, RootResolver }
+import caliban.execution.Field
+import caliban.schema.Types
+import caliban.Value
 
 case class ProductArgs[T](keyValues: Map[String, String])
 
 object CalibanIntegration:
+
+  def quillColumns(field: Field) =
+    def recurseFetchFields(field: Field): List[Field] =
+      if (Types.innerType(field.fieldType).kind == __TypeKind.OBJECT)
+          field.fields.flatMap(recurseFetchFields(_))
+      else
+        List(field)
+    field.fields.flatMap(recurseFetchFields(_)).map(_.name)
 
   def flattenToPairs(key: String, value: InputValue): List[(String, String)] =
     value match {
       // If it contains other keys, continue to get the pairs inside
       // e.g. for `name` in Person(name: Name, age: Int) this would be Name from which we need first:String, last:String
       case InputValue.ObjectValue(fields) => fields.toList.flatMap { case (k, v) => flattenToPairs(k, v) }
+      // Need to look at StringValue directly because calling .toInputString on it will give double quoting i.e. "\"value\""
+      case Value.StringValue(value)       => List((key, value))
       case _                              => List((key, value.toInputString))
     }
 

--- a/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationNestedSpec.scala
+++ b/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationNestedSpec.scala
@@ -1,0 +1,120 @@
+package io.getquill
+
+import io.getquill.context.ZioJdbc.DataSourceLayer
+import zio.{ZIO, Task}
+import io.getquill.context.ZioJdbc._
+import caliban.execution.Field
+import caliban.schema.ArgBuilder
+import caliban.GraphQL.graphQL
+import caliban.schema.Annotations.GQLDescription
+import caliban.RootResolver
+import io.getquill.CalibanIntegration._
+
+class CalibanIntegrationNestedSpec extends CalibanSpec {
+  import Ctx._
+
+  object Nested:
+    import NestedSchema._
+    object Dao:
+      def personAddress(columns: List[String], filters: Map[String, String]) =
+        Ctx.run {
+          query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
+            .map((p, a) => PersonAddressNested(p.id, p.name, p.age, a.map(_.street)))
+            .filterByKeys(filters)
+            .filterColumns(columns)
+            .take(10)
+        }.provideLayer(zioDS).tap(list => {
+          println(s"Results: $list for columns: $columns and filters: ${io.getquill.util.Messages.qprint(filters)}")
+          ZIO.unit
+        })
+        .tapError(e => {
+          println(s"ERROR $e")
+          ZIO.unit
+        })
+
+  case class Queries(
+    personAddressNested: Field => (ProductArgs[NestedSchema.PersonAddressNested] => Task[List[NestedSchema.PersonAddressNested]])
+  )
+
+  val api = graphQL(
+      RootResolver(
+        Queries(
+          personAddressNested =>
+            (productArgs =>
+              Nested.Dao.personAddress(quillColumns(personAddressNested), productArgs.keyValues)
+            ),
+        )
+      )
+    )
+
+  "Caliban integration should work for nested object" - {
+    "with no top-level filter" in {
+      val query =
+        """
+        {
+          personAddressNested {
+            id
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressNested":[{"id":1},{"id":2},{"id":3}]}"""
+    }
+
+    "top-level filter is nested field" in {
+      val query =
+        """
+        {
+          personAddressNested(name: { first: "One" }) {
+            id
+            name {
+              first
+            }
+          }
+        }"""
+      val output = unsafeRunQuery(query)
+      println("========== QUERY OUTPUT: " + output)
+      output mustEqual """{"personAddressNested":[{"id":1,"name":{"first":"One"}}]}"""
+    }
+
+    "top-level filter is nested field and does not occur in body" in {
+      val query =
+        """
+        {
+          personAddressNested(name: { first: "One" }) {
+            id
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressNested":[{"id":1}]}"""
+    }
+
+    "with one field in the nested object" in {
+      val query =
+        """
+        {
+          personAddressNested(id: 1) {
+            id
+            age
+            name {
+              first
+            }
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressNested":[{"id":1,"age":44,"name":{"first":"One"}}]}"""
+    }
+
+    "with multiple fields in the nested object" in {
+      val query =
+        """
+        {
+          personAddressNested(id: 1) {
+            id
+            age
+            name {
+              first
+              last
+            }
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressNested":[{"id":1,"age":44,"name":{"first":"One","last":"A"}}]}"""
+    }
+  }
+}

--- a/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationSpec.scala
+++ b/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationSpec.scala
@@ -1,9 +1,5 @@
 package io.getquill
 
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-
 import io.getquill.context.ZioJdbc.DataSourceLayer
 import zio.{ZIO, Task}
 import io.getquill.context.ZioJdbc._
@@ -14,69 +10,29 @@ import caliban.schema.Annotations.GQLDescription
 import caliban.RootResolver
 import io.getquill.CalibanIntegration._
 
-class CalibanIntegrationSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
-  object Ctx extends PostgresZioJdbcContext(Literal)
+class CalibanIntegrationSpec extends CalibanSpec {
   import Ctx._
-  lazy val zioDS = DataSourceLayer.fromPrefix("testPostgresDB")
-
-  extension [R, E, A](qzio: ZIO[Any, Throwable, A])
-    def unsafeRunSync(): A = zio.Runtime.default.unsafeRun(qzio)
-
-  override def beforeAll() = {
-    import Flat._
-    (for {
-        _ <- Ctx.run(infix"TRUNCATE TABLE AddressT, PersonT RESTART IDENTITY".as[Delete[PersonT]])
-        _ <- Ctx.run(liftQuery(List(
-          PersonT(1, "One", "A", 44),
-          PersonT(2, "Two", "B", 55),
-          PersonT(3, "Three", "C", 66)
-        )).foreach(row => query[PersonT].insert(row)))
-        _ <- Ctx.run(liftQuery(List(
-          AddressT(1, "123 St"),
-          AddressT(2, "789 St")
-        )).foreach(row => query[AddressT].insert(row)))
-      } yield ()
-    ).onDataSource.provideLayer(zioDS).unsafeRunSync()
-  }
-
-  override def afterAll() = {
-    import Flat._
-    Ctx.run(infix"TRUNCATE TABLE AddressT, PersonT RESTART IDENTITY".as[Delete[PersonT]]).onDataSource.provideLayer(zioDS).unsafeRunSync()
-  }
 
   object Flat:
-    case class PersonT(id: Int, first: String, last: String, age: Int)
-    case class AddressT(ownerId: Int, street: String)
-    case class PersonAddressFlat(id: Int, first: String, last: String, age: Int, street: Option[String])
+    import FlatSchema._
     object Dao:
-      def personAddress(columns: List[String], filters: Map[String, String]) =
+      def personAddress(columns: List[String], filters: Map[String, String]): ZIO[Any, Throwable, List[PersonAddress]] =
+        ZIO.effect {
+          println(s"======= Beginning Results for columns: $columns")
+        } >>>
         Ctx.run {
           query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
-            .map((p, a) => PersonAddressFlat(p.id, p.first, p.last, p.age, a.map(_.street)))
+            .map((p, a) => PersonAddress(p.id, p.first, p.last, p.age, a.map(_.street)))
             .filterByKeys(filters)
             .filterColumns(columns)
             .take(10)
-        }.onDataSource.provideLayer(zioDS)
-
-  object Nested:
-    case class Name(first: String, last: String)
-    case class PersonT(id: Int, name: Name, age: Int)
-    case class AddressT(ownerId: Int, street: String)
-    // Needs to be named differently from Flat.PersonAddress___ since Caliban infers from this class & name must be different
-    case class PersonAddressNested(id: Int, name: Name, age: Int, street: Option[String])
-    object Dao:
-      def personAddress(columns: List[String], filters: Map[String, String]) =
-        Ctx.run {
-          query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
-            .map((p, a) => PersonAddressNested(p.id, p.name, p.age, a.map(_.street)))
-            .filterByKeys(filters)
-            .filterColumns(columns)
-            .take(10)
-        }.onDataSource.provideLayer(zioDS)
+        }.provideLayer(zioDS).tap(list => {
+          println(s"Results: $list for columns: $columns")
+          ZIO.unit
+        })
 
   case class Queries(
-    personAddressFlat: Field => (ProductArgs[Flat.PersonAddressFlat] => Task[List[Flat.PersonAddressFlat]]),
-    personAddressJoined: Field => (ProductArgs[Nested.PersonAddressNested] => Task[List[Nested.PersonAddressNested]])
+    personAddressFlat: Field => (ProductArgs[FlatSchema.PersonAddress] => Task[List[FlatSchema.PersonAddress]]),
   )
 
   val api = graphQL(
@@ -84,50 +40,48 @@ class CalibanIntegrationSpec extends AnyFreeSpec with Matchers with BeforeAndAft
         Queries(
           personAddressFlat =>
             (productArgs =>
-              Flat.Dao.personAddress(personAddressFlat.fields.map(_.name), productArgs.keyValues)
-            ),
-          personAddressNested =>
-            (productArgs =>
-              Nested.Dao.personAddress(personAddressNested.fields.map(_.name), productArgs.keyValues)
-            ),
+              Flat.Dao.personAddress(quillColumns(personAddressFlat), productArgs.keyValues)
+            )
         )
       )
     )
 
-  def unsafeRunQuery(queryString: String) =
-    (for {
-      interpreter <- api.interpreter
-      result      <- interpreter.execute(queryString)
-    } yield (result)).unsafeRunSync()
-
-  object CalibanQueries:
-    // Purposely filtering by a column that is not in the selection to test this case
-    val flatWithJoin =
-      """
-      {
-        personAddressFlat(first: One) {
-          id
-          first
-          last
-          street
-        }
-      }"""
-    val flatWithJoinColNotIncluded =
-      """
-      {
-        personAddressFlat(first: One) {
-          id
-          last
-          street
-        }
-      }"""
-
-  "Caliban integration should work for" - {
-    "flat object with filteration column included" in {
-      unsafeRunQuery(CalibanQueries.flatWithJoin).data.toString mustEqual """{"personAddressFlat":[{"id":1,"first":"One","last":"A","street":"123 St"}]}"""
+  "Caliban integration should work for flat object" - {
+    "with no filters" in {
+      val query =
+        """
+        {
+          personAddressFlat {
+            id
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressFlat":[{"id":1},{"id":2},{"id":3}]}"""
     }
-    "flat object with filteration column excluded" in {
-      unsafeRunQuery(CalibanQueries.flatWithJoinColNotIncluded).data.toString mustEqual """{"personAddressFlat":[{"id":1,"last":"A","street":"123 St"}]}"""
+
+    "with filteration column included" in {
+      val query =
+        """
+        {
+          personAddressFlat(first: "One") {
+            id
+            first
+            last
+            street
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressFlat":[{"id":1,"first":"One","last":"A","street":"123 St"}]}"""
+    }
+    "with no filteration column excluded" in {
+      val query =
+        """
+        {
+          personAddressFlat(first: "One") {
+            id
+            last
+            street
+          }
+        }"""
+      unsafeRunQuery(query) mustEqual """{"personAddressFlat":[{"id":1,"last":"A","street":"123 St"}]}"""
     }
   }
 }

--- a/quill-caliban/src/test/scala/io/getquill/CalibanSpec.scala
+++ b/quill-caliban/src/test/scala/io/getquill/CalibanSpec.scala
@@ -1,0 +1,55 @@
+package io.getquill
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import zio.{ZIO, Task}
+import caliban.GraphQL
+import io.getquill.context.ZioJdbc.DataSourceLayer
+import io.getquill.util.ContextLogger
+
+trait CalibanSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
+  object Ctx extends PostgresZioJdbcContext(Literal)
+  import Ctx._
+  lazy val zioDS = DataSourceLayer.fromPrefix("testPostgresDB")
+
+  private val logger = ContextLogger(this.getClass)
+
+  // FlatSchema and NestedSchema share the same DB data so only need to create it using one of them
+  override def beforeAll() = {
+    import FlatSchema._
+    (for {
+        _ <- Ctx.run(infix"TRUNCATE TABLE AddressT, PersonT RESTART IDENTITY".as[Delete[PersonT]])
+        _ <- Ctx.run(liftQuery(ExampleData.people).foreach(row => query[PersonT].insert(row)))
+        _ <- Ctx.run(liftQuery(ExampleData.addresses).foreach(row => query[AddressT].insert(row)))
+      } yield ()
+    ).provideLayer(zioDS).unsafeRunSync()
+  }
+
+  // override def afterAll() = {
+  //   import FlatSchema._
+  //   Ctx.run(infix"TRUNCATE TABLE AddressT, PersonT RESTART IDENTITY".as[Delete[PersonT]]).provideLayer(zioDS).unsafeRunSync()
+  // }
+
+  def api: GraphQL[Any]
+
+  extension [R, E, A](qzio: ZIO[Any, Throwable, A])
+    def unsafeRunSync(): A = zio.Runtime.default.unsafeRun(qzio)
+
+  def unsafeRunQuery(queryString: String) =
+    val output =
+      (for {
+        interpreter <- api.interpreter
+        result      <- interpreter.execute(queryString)
+      } yield (result)
+      ).tapError{ e =>
+        fail("GraphQL Validation Error", e)
+        ZIO.unit
+      }.unsafeRunSync()
+
+    if (output.errors.length != 0)
+      fail(s"GraphQL Validation Failures: ${output.errors}")
+    else
+      output.data.toString
+  end unsafeRunQuery
+}

--- a/quill-caliban/src/test/scala/io/getquill/Schema.scala
+++ b/quill-caliban/src/test/scala/io/getquill/Schema.scala
@@ -1,0 +1,49 @@
+package io.getquill
+
+object FlatSchema:
+  case class PersonT(id: Int, first: String, last: String, age: Int)
+  case class AddressT(ownerId: Int, street: String)
+  case class PersonAddress(id: Int, first: String, last: String, age: Int, street: Option[String])
+  object ExampleData:
+    val people =
+      List(
+        PersonT(1, "One", "A", 44),
+        PersonT(2, "Two", "B", 55),
+        PersonT(3, "Three", "C", 66)
+      )
+    val addresses =
+      List(
+        AddressT(1, "123 St"),
+        AddressT(2, "789 St")
+      )
+    val personAddress =
+      List(
+        PersonAddress(1, "One", "A", 44, Some("123 St")),
+        PersonAddress(2, "Two", "B", 55, Some("123 St")),
+        PersonAddress(3, "Three", "C", 66, None),
+      )
+
+object NestedSchema:
+  case class Name(first: String, last: String)
+  case class PersonT(id: Int, name: Name, age: Int)
+  case class AddressT(ownerId: Int, street: String)
+  // Needs to be named differently from Flat.PersonAddress___ since Caliban infers from this class & name must be different
+  case class PersonAddressNested(id: Int, name: Name, age: Int, street: Option[String])
+  object ExampleData:
+    val people =
+      List(
+        PersonT(1, Name("One", "A"), 44),
+        PersonT(2, Name("Two", "B"), 55),
+        PersonT(3, Name("Three", "C"), 66)
+      )
+    val addresses =
+      List(
+        AddressT(1, "123 St"),
+        AddressT(2, "789 St")
+      )
+    val personAddress =
+      List(
+        PersonAddressNested(1, Name("One", "A"), 44, Some("123 St")),
+        PersonAddressNested(2, Name("Two", "B"), 55, Some("123 St")),
+        PersonAddressNested(3, Name("Three", "C"), 66, None),
+      )

--- a/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
+++ b/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
@@ -1,0 +1,109 @@
+package io.getquill
+
+import caliban.GraphQL.graphQL
+import caliban.schema.Annotations.GQLDescription
+import caliban.{RootResolver, ZHttpAdapter}
+import zhttp.http._
+import zhttp.service.Server
+import zio.{ExitCode, ZEnv, ZIO}
+import io.getquill._
+import io.getquill.context.qzio.ImplicitSyntax._
+import io.getquill.context.ZioJdbc._
+import io.getquill.util.LoadConfig
+import zio.console.putStrLn
+import zio.{ App, ExitCode, Has, URIO, Task }
+import java.io.Closeable
+import javax.sql.DataSource
+
+import scala.language.postfixOps
+import caliban.execution.Field
+import caliban.schema.ArgBuilder
+import io.getquill.CalibanIntegration._
+import io.getquill.util.ContextLogger
+import io.getquill
+import io.getquill.FlatSchema._
+
+
+object Dao:
+  case class PersonAddressPlanQuery(plan: String, pa: List[PersonAddress])
+  private val logger = ContextLogger(classOf[Dao.type])
+
+  object Ctx extends PostgresZioJdbcContext(Literal)
+  import Ctx._
+  lazy val ds = JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource
+  given Implicit[Has[DataSource]] = Implicit(Has(ds))
+
+  inline def q(inline columns: List[String], inline filters: Map[String, String]) =
+    quote {
+      query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
+        .map((p, a) => PersonAddress(p.id, p.first, p.last, p.age, a.map(_.street)))
+        .filterColumns(columns)
+        .filterByKeys(filters)
+        .take(10)
+    }
+  inline def plan(inline columns: List[String], inline filters: Map[String, String]) =
+    quote { infix"EXPLAIN ${q(columns, filters)}".pure.as[Query[String]] }
+
+  def personAddress(columns: List[String], filters: Map[String, String]) =
+    println(s"Getting columns: $columns")
+    run(q(columns, filters)).implicitDS.mapError(e => {
+      logger.underlying.error("personAddress query failed", e)
+      e
+    })
+
+  def personAddressPlan(columns: List[String], filters: Map[String, String]) =
+    run(plan(columns, filters), OuterSelectWrap.Never).map(_.mkString("\n")).implicitDS.mapError(e => {
+      logger.underlying.error("personAddressPlan query failed", e)
+      e
+    })
+
+  def resetDatabase() =
+    (for {
+      _ <- run(infix"TRUNCATE TABLE AddressT, PersonT RESTART IDENTITY".as[Delete[PersonT]])
+      _ <- run(liftQuery(ExampleData.people).foreach(row => query[PersonT].insert(row)))
+      _ <- run(liftQuery(ExampleData.addresses).foreach(row => query[AddressT].insert(row)))
+    } yield ()).implicitDS
+end Dao
+
+object CalibanExample extends zio.App:
+
+  case class Queries(
+      personAddress: Field => (ProductArgs[PersonAddress] => Task[List[PersonAddress]]),
+      personAddressPlan: Field => (ProductArgs[PersonAddress] => Task[Dao.PersonAddressPlanQuery])
+  )
+
+  val endpoints =
+     graphQL(
+      RootResolver(
+        Queries(
+          personAddress =>
+            (productArgs =>
+              Dao.personAddress(quillColumns(personAddress), productArgs.keyValues)
+            ),
+          personAddressPlan =>
+            (productArgs => {
+              val cols = quillColumns(personAddressPlan)
+              (Dao.personAddressPlan(cols, productArgs.keyValues) zip Dao.personAddress(cols, productArgs.keyValues)).map(
+                (pa, plan) => Dao.PersonAddressPlanQuery(pa, plan)
+              )
+            })
+        )
+      )
+    ).interpreter
+
+  val myApp = for {
+    _ <- Dao.resetDatabase()
+    interpreter <- endpoints
+    _ <- Server.start(
+        port = 8088,
+        http = Http.route { case _ -> Root / "api" / "graphql" =>
+          ZHttpAdapter.makeHttpService(interpreter)
+        }
+      )
+      .forever
+  } yield ()
+
+  override def run(args: List[String]): ZIO[ZEnv, Nothing, ExitCode] =
+    myApp.exitCode
+
+end CalibanExample


### PR DESCRIPTION
Caliban `productArgs` were not properly being handled, they were only being passed in on the top level.
Also, in `flattenToPairs`, strings had `""ExtraQuotes""` around them.
Also added tests for many more cases with nested data.

Note that unless the Caliban schema is correctly matched to the output data, Circe deserialization will cause NPEs.
For example when the graphQL query:
```
{
  personAddressNested(id: 1) {
    id
    age
    name {
      first
      last
    }
  }
}
```
And the following schema & query:
```scala
case class Name(first: String, last: String)
case class PersonT(id: Int, name: Name, age: Int)
case class AddressT(ownerId: Int, street: String)
case class PersonAddressNested(id: Int, name: Name, age: Int, street: Option[String])

query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
  .map((p, a) => PersonAddressNested(p.id, p.name, p.age, a.map(_.street)))
  .filterByKeys(filters)
  .filterColumns(columns)
  .take(10)
```
If the caliban integration messes up and does not pass any of the columns: `List("id", "age", "first", "last")` into the `columns` variable being passed to the query.... let's say the last two columns are missing: `columns:List("id", "age")` then the resulting data will look like:
```scala
List(
PersonAddressNested(1, Name(null, null), 44)
)
```
Instead of:
```scala
List(
PersonAddressNested(1, Name("One", "A"), 44)
)
```
Circe will cause an NPE during deserialization. On the caliban side it will look like this:
```
java.lang.NullPointerException:
  at caliban.Value$StringValue.toString(Value.scala:74)
  at caliban.ResponseValue$ObjectValue.toString$$anonfun$1(Value.scala:39)
  at scala.collection.immutable.List.map(List.scala:246)
  at caliban.ResponseValue$ObjectValue.toString(Value.scala:39)
```
If you are running it from ZIO-Http it will look like this:
```
[error] Fiber failed.
[error] An unchecked error was produced.
[error] java.lang.NullPointerException
[error]         at io.circe.Printer$PrintingFolder.onString(Printer.scala:309)
[error]         at io.circe.Printer$PrintingFolder.onString(Printer.scala:303)
[error]         at io.circe.Json$JString.foldWith(Json.scala:364)
[error]         at io.circe.JsonObject$LinkedHashMapJsonObject.appendToFolder(JsonObject.scala:343)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Json$JObject.foldWith(Json.scala:426)
[error]         at io.circe.JsonObject$LinkedHashMapJsonObject.appendToFolder(JsonObject.scala:343)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Json$JObject.foldWith(Json.scala:426)
[error]         at io.circe.Printer$PrintingFolder.onArray(Printer.scala:345)
[error]         at io.circe.Printer$PrintingFolder.onArray(Printer.scala:335)
[error]         at io.circe.Json$JArray.foldWith(Json.scala:395)
[error]         at io.circe.JsonObject$LinkedHashMapJsonObject.appendToFolder(JsonObject.scala:343)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Json$JObject.foldWith(Json.scala:426)
[error]         at io.circe.JsonObject$LinkedHashMapJsonObject.appendToFolder(JsonObject.scala:343)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Printer$PrintingFolder.onObject(Printer.scala:359)
[error]         at io.circe.Json$JObject.foldWith(Json.scala:426)
[error]         at io.circe.Printer.print(Printer.scala:194)
[error]         at io.circe.Json.spaces2(Json.scala:122)
[error]         at io.circe.Json.toString(Json.scala:215)
[error]         at caliban.ZHttpAdapter$.caliban$ZHttpAdapter$$anon$2$$_$applyOrElse$$anonfun$2$$anonfun$1(ZHttpAdapter.scala:107)
[error]         at zio.ZIO$MapFn.apply(ZIO.scala:4438)
```
