### PR TITLE
Disable Ast/Quat Serialization for some test packages

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/TestStuff.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/TestStuff.scala
@@ -1,0 +1,17 @@
+package io.getquill.context.qzio
+
+// sealed trait Symbol
+// object Symbol:
+//   case object `==` extends Symbol
+//   case object `>=` extends Symbol
+
+
+// enum Symbol:
+//   case `_==`
+//   case `>=`
+
+// object Match:
+//   def unapply(symbol: Symbol) =
+//     symbol match
+//       case Symbol.`_==` => "foo"
+//       case Symbol.`>=` => "bar"

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/TestUse.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/TestUse.scala
@@ -1,0 +1,1 @@
+package io.getquill.context.qzio

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/DontSerialize.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/DontSerialize.scala
@@ -1,0 +1,8 @@
+package io.getquill.ported.quotationspec
+
+import io.getquill.parser.DoSerialize
+import io.getquill.parser.SerializationBehavior
+
+// Will disable AST serialization for quotes in packages/subpackages with this inside.
+given DoSerialize with
+  override type BehaviorType = SerializationBehavior.Serialize

--- a/quill-sql/src/main/scala/io/getquill/parser/SerializationBehavior.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/SerializationBehavior.scala
@@ -1,0 +1,11 @@
+package io.getquill.parser
+
+sealed trait SerializationBehavior
+object SerializationBehavior:
+  sealed trait Serialize extends SerializationBehavior
+  case object Serialize extends Serialize
+  sealed trait Skip extends SerializationBehavior
+  case object Skip extends Skip
+
+trait DoSerialize:
+  type BehaviorType <: SerializationBehavior


### PR DESCRIPTION
Need to test quote/unquote without quat/ast serialization in order to know that lifter/unlifter works. Adding capability to turn this off in code.