### PR TITLE
ProtoQuill does not support Scala 2 style implicit extensions. Warn about it

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -867,10 +867,9 @@ class ComplexValueParser(rootParse: Parser)(using Quotes)
 class GenericExpressionsParser(val rootParse: Parser)(using Quotes) extends Parser(rootParse) with PropertyParser {
   import quotes.reflect.{Constant => TConstant, Ident => TIdent, Apply => TApply, _}
 
-
-
-
   def attempt = {
+    case expr @ ImplicitClassExtensionPattern(clsName, constructorArg, methodName) =>
+      report.throwError(ImplicitClassExtensionPattern.errorMessage(expr, clsName, constructorArg, methodName), expr)
 
     case AnyProperty(property) => property
 


### PR DESCRIPTION
ProtoQuill does not support Scala 2 style implicit extensions classes. Warn the user about it and show how to change it.

TODO Needs test!