### PR TITLE
Introduce implicit hint to fail non-static query build

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/SplicingBehavior.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/SplicingBehavior.scala
@@ -1,0 +1,30 @@
+package io.getquill.context
+
+import scala.quoted._
+
+sealed trait SplicingBehavior
+object SplicingBehavior:
+  sealed trait FailOnDynamic extends SplicingBehavior
+  case object FailOnDynamic extends FailOnDynamic
+  sealed trait AllowDynamic extends SplicingBehavior
+  case object AllowDynamic extends AllowDynamic
+
+trait SplicingBehaviorHint:
+  type BehaviorType <: SplicingBehavior
+
+object HasDynamicSplicingHint:
+  object InExpr:
+    def unapply(value: Expr[SplicingBehaviorHint])(using Quotes): Boolean =
+      import quotes.reflect._
+      val memberSymbol = value.asTerm.tpe.termSymbol.memberType("BehaviorType")
+      value.asTerm.select(memberSymbol).tpe <:< TypeRepr.of[SplicingBehavior.FailOnDynamic]
+
+  def fail(using Quotes): Boolean =
+    import quotes.reflect._
+    Expr.summon[SplicingBehaviorHint] match
+      case Some(HasDynamicSplicingHint.InExpr()) =>
+        true
+      case Some(value) =>
+        false
+      case _ =>
+        false

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleBatchWithInfix.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleBatchWithInfix.scala
@@ -1,10 +1,15 @@
 package io.getquill.sanity
 
 import io.getquill._
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 object SimpleBatchWithInfix extends Spec {
   val ctx = new MirrorContext(MirrorSqlDialect, Literal)
   import ctx._
+
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
 
   "batch must work with simple infix" in {
     case class Person[T](name: String, age: Int)

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapRunSanityTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapRunSanityTest.scala
@@ -11,9 +11,14 @@ import io.getquill.quat.Quat
 import io.getquill.quat.quatOf
 import io.getquill.quote
 import io.getquill.query
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 class SimpleMapRunSanityTest extends Spec {
   case class SanePerson(name: String, age: Int)
+
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
 
   "simple test for inline query and map translated to the mirror idiom" in {
     inline def q = quote {

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapSanityTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapSanityTest.scala
@@ -6,9 +6,14 @@ import io.getquill._
 import io.getquill.ast._
 import io.getquill.Quoted
 import io.getquill.quat.quatOf
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 class SimpleMapSanityTest extends Spec {
   case class SanePerson(name: String, age: Int)
+
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
 
   "simple test for inline query and map" in {
     inline def q = quote {

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapSqlSanityTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleMapSqlSanityTest.scala
@@ -7,13 +7,18 @@ import io.getquill.ast._
 import io.getquill.Quoted
 
 import io.getquill.quat.quatOf
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 class SimpleMapSqlSanityTest extends Spec {
   case class SanePerson(name: String, age: Int)
 
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
+
   "simple test for one inline query converted to sql" in {
     inline def q = quote {
-      query[SanePerson] // helloo
+      query[SanePerson]
     }
     inline def qq = quote {
       q.map(p => p.name)

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimplePrepareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimplePrepareSpec.scala
@@ -3,10 +3,15 @@ package io.getquill.sanity
 import io.getquill._
 import io.getquill.ast._
 import io.getquill.Quoted
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 class SimplePrepareSpec extends Spec {
   val ctx = SqlMirrorContext(PostgresDialect, Literal)
   import ctx._
+
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
 
   "prepare should work for" - {
     case class Person(name: String, age: Int)

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleQuerySchemaTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleQuerySchemaTest.scala
@@ -2,9 +2,14 @@ package io.getquill.sanity
 
 import io.getquill._
 import io.getquill.generic._
+import io.getquill.context.SplicingBehaviorHint
+import io.getquill.context.SplicingBehavior
 
 
 class SimpleQuerySchemaTest extends Spec {
+
+  given SplicingBehaviorHint with
+    override type BehaviorType = SplicingBehavior.FailOnDynamic
 
   val ctx = new MirrorContext(MirrorSqlDialect, Literal)
   import ctx._


### PR DESCRIPTION
Can add a implicit directive `HasDynamicSplicingHint` in order to fail dynamic build.