### PR TITLE
Bump ZIO to 1.0.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -224,8 +224,8 @@ lazy val `quill-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "1.0.8",
-        "dev.zio" %% "zio-streams" % "1.0.8"
+        "dev.zio" %% "zio" % "1.0.12",
+        "dev.zio" %% "zio-streams" % "1.0.12"
       )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")


### PR DESCRIPTION
The library needs to be built with a zio version of at least 1.0.10 to fix this issue: https://github.com/zio/zio/issues/5530
I could not bump to the latest version (1.0.13) because that would require moving to scala 3.1.0