### PR TITLE
Remove bad trailing comma

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/util/Format.scala
+++ b/quill-sql/src/main/scala/io/getquill/util/Format.scala
@@ -66,7 +66,7 @@ object Format {
             |  ${Format(Printer.TreeShortCode.show(term)) }
             |==== Extractors ===
             |  ${Format(Printer.TreeStructure.show(term))}
-            |""".stripMargin,
+            |""".stripMargin
       } else {
         Format(Printer.TreeShortCode.show(term))
       }


### PR DESCRIPTION
There is a [PR](https://github.com/lampepfl/dotty/pull/14517) up to remove bad trailing commas from dotty. This bad trailing comma is breaking the community build.

@getquill/maintainers
