### PR TITLE
Concrete run method signatures in contexts

### DIFF
--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -18,6 +18,7 @@ import io.getquill.context.cassandra.CassandraStandardContext
 import io.getquill.context.Context
 import io.getquill.context.cassandra.CassandraPrepareContext
 import io.getquill.context.AsyncFutureCache
+import scala.annotation.targetName
 
 object CassandraZioContext extends CioOps {
   type CIO[T] = ZIO[Has[CassandraZioSession], Throwable, T]
@@ -79,6 +80,17 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
   override type PrepareRow = BoundStatement
   override type ResultRow = Row
   override type Session = CassandraZioSession
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): ZIO[Has[CassandraZioSession], Throwable, List[T]] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): ZIO[Has[CassandraZioSession], Throwable, List[T]] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): ZIO[Has[CassandraZioSession], Throwable, T] = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): ZIO[Has[CassandraZioSession], Throwable, Unit] = InternalApi.runAction(quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): ZIO[Has[CassandraZioSession], Throwable, Unit] = InternalApi.runBatchAction(quoted)
 
   // Don't need a Runner method because for the Zio Cassandra Context the
   // ExecutionContext is provided by the ZIO runtime.

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -12,6 +12,7 @@ import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters._
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.annotation.targetName
 
 class CassandraAsyncContext[N <: NamingStrategy](
   naming:                     N,
@@ -45,6 +46,17 @@ class CassandraAsyncContext[N <: NamingStrategy](
   override type RunBatchActionResult = Unit
   // In ProtoQuill this is defined in CassandraRowContext and the Runner is ExecutionContext
   // override type Runner = Unit
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): Future[List[T]] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): Future[List[T]] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): Future[T] = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): Future[Unit] = InternalApi.runAction(quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): Future[Unit] = InternalApi.runBatchAction(quoted)
 
   // override def performIO[T](io: IO[T, _], transactional: Boolean = false)(implicit ec: ExecutionContext): Result[T] = {
   //   if (transactional) logger.underlying.warn("Cassandra doesn't support transactions, ignoring `io.transactional`")

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -7,6 +7,7 @@ import io.getquill.context.ExecutionInfo
 import io.getquill.util.{ ContextLogger, LoadConfig }
 
 import scala.jdk.CollectionConverters._
+import scala.annotation.targetName
 
 class CassandraSyncContext[N <: NamingStrategy](
   naming:                     N,
@@ -28,6 +29,17 @@ class CassandraSyncContext[N <: NamingStrategy](
   override type RunActionResult = Unit
   override type RunBatchActionResult = Unit
   override type Runner = Unit
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): List[T] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): List[T] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): T = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): Unit = InternalApi.runAction(quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): Unit = InternalApi.runBatchAction(quoted)
 
   override protected def context: Runner = ()
 

--- a/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/PostgresJAsyncContext.scala
@@ -10,6 +10,8 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 
 import scala.jdk.CollectionConverters._
+import scala.annotation.targetName
+import scala.concurrent.Future
 
 trait PostgresJAsyncContextBase[N <: NamingStrategy]
   extends JAsyncContextBase[PostgresDialect, N]
@@ -24,6 +26,21 @@ class PostgresJAsyncContext[N <: NamingStrategy](naming: N, pool: ConnectionPool
   def this(naming: N, config: PostgresJAsyncContextConfig) = this(naming, config.pool)
   def this(naming: N, config: Config) = this(naming, PostgresJAsyncContextConfig(config))
   def this(naming: N, configPrefix: String) = this(naming, LoadConfig(configPrefix))
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): Future[Seq[T]] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): Future[Seq[T]] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): Future[T] = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): Future[Long] = InternalApi.runAction(quoted)
+  @targetName("runActionReturning")
+  inline def run[E, T](inline quoted: Quoted[ActionReturning[E, T]]): Future[T] = InternalApi.runActionReturning[E, T](quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): Future[Seq[Long]] = InternalApi.runBatchAction(quoted)
+  @targetName("runBatchActionReturning")
+  inline def run[I, T, A <: Action[I] & QAC[I, T]](inline quoted: Quoted[BatchAction[A]]): Future[Seq[T]] =  InternalApi.runBatchActionReturning(quoted)
 
   override protected def extractActionResult[O](returningAction: ReturnAction, returningExtractor: Extractor[O])(result: DBQueryResult): O =
     result.getRows.asScala

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -4,7 +4,6 @@ import io.getquill.context.ZioJdbc._
 import io.getquill.context.jdbc.JdbcContextTypes
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.{ ExecutionInfo, ProtoContext, ContextVerbStream }
-import io.getquill.{ NamingStrategy, ReturnAction }
 import zio.Exit.{ Failure, Success }
 import zio.stream.ZStream
 import zio.{ FiberRef, Has, Runtime, UIO, ZIO, ZManaged }
@@ -12,6 +11,8 @@ import zio.{ FiberRef, Has, Runtime, UIO, ZIO, ZManaged }
 import java.sql.{ Array => _, _ }
 import javax.sql.DataSource
 import scala.util.Try
+import scala.annotation.targetName
+import io.getquill._
 
 /**
  * Quill context that executes JDBC queries inside of ZIO. Unlike most other contexts
@@ -70,6 +71,21 @@ abstract class ZioJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] ext
   override type PrepareActionResult = QCIO[PrepareRow]
   override type PrepareBatchActionResult = QCIO[List[PrepareRow]]
   override type Session = Connection
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): ZIO[Has[DataSource], SQLException, List[T]] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): ZIO[Has[DataSource], SQLException, List[T]] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): ZIO[Has[DataSource], SQLException, T] = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): ZIO[Has[DataSource], SQLException, Long] = InternalApi.runAction(quoted)
+  @targetName("runActionReturning")
+  inline def run[E, T](inline quoted: Quoted[ActionReturning[E, T]]): ZIO[Has[DataSource], SQLException, T] = InternalApi.runActionReturning[E, T](quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): ZIO[Has[DataSource], SQLException, List[Long]] = InternalApi.runBatchAction(quoted)
+  @targetName("runBatchActionReturning")
+  inline def run[I, T, A <: Action[I] & QAC[I, T]](inline quoted: Quoted[BatchAction[A]]): ZIO[Has[DataSource], SQLException, List[T]] =  InternalApi.runBatchActionReturning(quoted)
 
   val currentConnection: FiberRef[Option[Connection]] =
     Runtime.default.unsafeRun(FiberRef.make(None))

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
@@ -6,6 +6,7 @@ import io.getquill.Prefix
 import io.getquill._
 import zio.ZLayer
 import javax.sql.DataSource
+import java.sql.SQLException
 
 class ZioJdbcContextSpec extends ZioSpec {
 

--- a/quill-sql/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/MirrorContext.scala
@@ -5,6 +5,7 @@ import io.getquill.context._
 import io.getquill.Quoted
 import io.getquill.idiom.Idiom
 import io.getquill.NamingStrategy
+import scala.annotation.targetName
 
 // TODO Note needed, cleanup
 sealed trait Dummy
@@ -64,6 +65,21 @@ with MirrorEncoders { self =>
   case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningBehavior: ReturnAction, info: ExecutionInfo)
   case class BatchActionMirror(groups: List[(String, List[Row])], info: ExecutionInfo)
   case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T], info: ExecutionInfo)
+
+  @targetName("runQueryDefault")
+  inline def run[T](inline quoted: Quoted[Query[T]]): QueryMirror[T] = InternalApi.runQueryDefault(quoted)
+  @targetName("runQuery")
+  inline def run[T](inline quoted: Quoted[Query[T]], inline wrap: OuterSelectWrap): QueryMirror[T] = InternalApi.runQuery(quoted, wrap)
+  @targetName("runQuerySingle")
+  inline def run[T](inline quoted: Quoted[T]): QueryMirror[T] = InternalApi.runQuerySingle(quoted)
+  @targetName("runAction")
+  inline def run[E](inline quoted: Quoted[Action[E]]): ActionMirror = InternalApi.runAction(quoted)
+  @targetName("runActionReturning")
+  inline def run[E, T](inline quoted: Quoted[ActionReturning[E, T]]): ActionReturningMirror[T] = InternalApi.runActionReturning(quoted)
+  @targetName("runBatchAction")
+  inline def run[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): BatchActionMirror = InternalApi.runBatchAction(quoted)
+  @targetName("runBatchActionReturning")
+  inline def run[I, T, A <: Action[I] & QAC[I, T]](inline quoted: Quoted[BatchAction[A]]): BatchActionReturningMirror[T] =  InternalApi.runBatchActionReturning(quoted)
 
   override def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner) =
     QueryMirror(string, prepare(Row(), session)._2, extractor, info)

--- a/quill-sql/src/main/scala/io/getquill/context/ContextVerbStream.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ContextVerbStream.scala
@@ -59,7 +59,7 @@ trait ContextVerbStream[Dialect <: io.getquill.idiom.Idiom, Naming <: NamingStra
   inline def _streamInternal[T](inline quoted: Quoted[Query[T]], fetchSize: Option[Int]): StreamResult[T] = {
     val ca = make.op[Nothing, T, StreamResult[T]] { arg =>
       val simpleExt = arg.extractor.requireSimple()
-      self.streamQuery(arg.fetchSize, arg.sql, arg.prepare.head, simpleExt.extract)(arg.executionInfo, _summonRunner())
+      self.streamQuery(arg.fetchSize, arg.sql, arg.prepare.head, simpleExt.extract)(arg.executionInfo, InternalApi._summonRunner())
     }
     QueryExecution.apply(quoted, ca, fetchSize)
   }


### PR DESCRIPTION
In previous version of ProtoQuill there was no InternalApi and the `run` methods were used
on a context directly. This caused a problem where doing something like:
```scala
  val list: List[RightType] = run(query[WrongType])
```
Will yield:
```
  Found: ctx.Result[List[WrongType]] Required: List[RightType]
```

This was even worse if the types were more complex e.g. for ZIO:
```scala
  val list: ZIO[Has[DataSource], SQLException, List[RightType]] = run(query[WrongType])
```
Will yield:
```
  Found: QuillContext.Result[List[WrongType]] Required: ZIO[Has[DataSource], SQLException, List[RightType]]
```
This is quite confusing. Therefore we define the methods in an object and then
delegate to these in the individual contexts.

That way the correct type will be asked for:
```
Found: ZIO[Has[DataSource], SQLException, List[WrongType]] 
Required: ZIO[Has[DataSource], SQLException, List[RightType]]
```