### PR TITLE
Remove redundancies with Scala2-Quill (and do necessary refactorings)

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -10,7 +10,7 @@ import scala.util.{ Success, Try }
 class CassandraContextSpec extends Spec {
   // val et = io.getquill.context.ExecutionType
   // val vvv = et.lifts
-  val unknown = ExecutionInfo(io.getquill.context.ExecutionType.Static, io.getquill.ast.NullValue)
+  val unknown = ExecutionInfo(io.getquill.context.ExecutionType.Static, io.getquill.ast.NullValue, io.getquill.quat.Quat.Value)
 
   "run non-batched action" - {
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -35,7 +35,7 @@ import io.getquill._
  *
  * If you are using a Plain Scala app however, you will need to manually run it e.g. using zio.Runtime
  * {{
- *   Runtime.default.unsafeRun(MyZioContext.run(query[Person]).provideLayer(zioDS))
+ *   Runtime.default.unsafeRun(MyZioContext.run(query[Person]).ContextTranslateProtoprovideLayer(zioDS))
  * }}
  *
  * Note however that the one exception to these cases are the `prepare` methods where a `ZIO[Has[Connection], SQLException, PreparedStatement]`

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
@@ -2,7 +2,7 @@ package io.getquill.context.jdbc
 
 import io.getquill._
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ ExecutionInfo, ContextVerbPrepare, ContextVerbPrepareLamba }
+import io.getquill.context.{ ExecutionInfo, ContextVerbPrepare, ContextVerbPrepareLambda }
 
 import java.sql._
 import io.getquill.util.ContextLogger
@@ -10,7 +10,7 @@ import io.getquill.util.ContextLogger
 trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
   extends JdbcContextVerbExecute[Dialect, Naming]
   with JdbcContextVerbPrepare[Dialect, Naming]
-  with ContextVerbPrepareLamba[Dialect, Naming] {
+  with ContextVerbPrepareLambda[Dialect, Naming] {
 
   // Need to re-define these here or they conflict with staged-prepare imported types
   override type PrepareQueryResult = Connection => Result[PreparedStatement]

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
@@ -2,7 +2,7 @@ package io.getquill.context.jdbc
 
 import io.getquill._
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ ExecutionInfo, ContextVerbPrepare, ContextVerbPrepareLamba }
+import io.getquill.context.{ ExecutionInfo, ContextVerbPrepare, ContextVerbPrepareLambda }
 
 import java.sql._
 import io.getquill.util.ContextLogger

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
@@ -42,8 +42,9 @@ trait SqliteJdbcTypes[N <: NamingStrategy] extends JdbcContextTypes[SqliteDialec
   val idiom = SqliteDialect
 }
 
-trait SqlServerExecuteOverride[N <: NamingStrategy] {
-  this: JdbcContextVerbExecute[SQLServerDialect, N] =>
+/** Use extension in stead of self-pointer to `JdbcContextVerbExecute[SQLServerDialect, N]` here. Want identical
+ * implementation to Scala2-Quill and doing it via self-pointer in Scala2-Quill will cause override-conflict errors in SqlServerExecuteOverride. */
+trait SqlServerExecuteOverride[N <: NamingStrategy] extends JdbcContextVerbExecute[SQLServerDialect, N] {
 
   private val logger = ContextLogger(classOf[SqlServerExecuteOverride[_]])
 

--- a/quill-sql/src/main/scala/io/getquill/context/BatchQueryExecution.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/BatchQueryExecution.scala
@@ -213,7 +213,7 @@ object DynamicBatchQueryExecution:
     // TODO this variable should go through BatchQueryExecution arguments and be propagated here
     val spliceAst = false
     val executionAst = if (spliceAst) outputAst else io.getquill.ast.NullValue
-    batchContextOperation.execute(ContextOperation.Argument(queryString, prepares.toArray, extractor, ExecutionInfo(ExecutionType.Dynamic, executionAst), None))
+    batchContextOperation.execute(ContextOperation.Argument(queryString, prepares.toArray, extractor, ExecutionInfo(ExecutionType.Dynamic, executionAst, topLevelQuat), None))
   }
 
 object BatchQueryExecution:
@@ -349,7 +349,7 @@ object BatchQueryExecution:
                   val prepare = '{ (row: PrepareRow, session: Session) => LiftsExtractor.apply[PrepareRow, Session]($injectedLiftsExpr, row, session) }
                   prepare
                 }) }
-              '{ $batchContextOperation.execute(ContextOperation.Argument(${Expr(query.basicQuery)}, $prepares.toArray, $extractor, ExecutionInfo(ExecutionType.Static, ${Lifter(state.ast)}), None)) }
+              '{ $batchContextOperation.execute(ContextOperation.Argument(${Expr(query.basicQuery)}, $prepares.toArray, $extractor, ExecutionInfo(ExecutionType.Static, ${Lifter(state.ast)}, ${Lifter.quat(topLevelQuat)}), None)) }
 
             case None =>
               // TODO report via trace debug

--- a/quill-sql/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/Context.scala
@@ -44,28 +44,6 @@ import io.getquill.metaprog.etc.ColumnsFlicer
 import io.getquill.context.Execution.ElaborationBehavior
 import io.getquill.OuterSelectWrap
 
-/**
- * Metadata related to query execution. Note that AST should be lazy so as not to be evaluated
- * at runtime (which would happen with a by-value property since `{ ExecutionInfo(stuff, ast) } is spliced
- * into a query-execution site)
- * TODO As a future optimization (if needed) could we introduce a compiler argument that would not even
- * splice the ASTs during the execute___ call-sites in the Context?
- */
-class ExecutionInfo(val executionType: ExecutionType, queryAst: =>Ast):
-  def ast: Ast = queryAst
-object ExecutionInfo:
-  def apply(executionType: ExecutionType, ast: =>Ast) = new ExecutionInfo(executionType, ast)
-
-trait ProtoStreamContext[Dialect <: Idiom, Naming <: NamingStrategy] extends RowContext {
-  type PrepareRow
-  type ResultRow
-
-  type Runner
-  type StreamResult[T]
-
-  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(executionInfo: ExecutionInfo, dc: Runner): StreamResult[T]
-}
-
 sealed trait RunnerSummoningBehavior
 object RunnerSummoningBehavior {
   sealed trait Implicit extends RunnerSummoningBehavior
@@ -96,7 +74,7 @@ import io.getquill.generic.DecodeAlternate
 
 trait ContextStandard[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   extends Context[Idiom, Naming]
-  with ContextVerbPrepareLamba[Idiom, Naming]
+  with ContextVerbPrepareLambda[Idiom, Naming]
 
 
 trait Context[Dialect <: Idiom, Naming <: NamingStrategy]

--- a/quill-sql/src/main/scala/io/getquill/context/ContextVerbPrepareLambda.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ContextVerbPrepareLambda.scala
@@ -44,10 +44,10 @@ import io.getquill.metaprog.etc.ColumnsFlicer
 import io.getquill.context.Execution.ElaborationBehavior
 import io.getquill.OuterSelectWrap
 
-trait ContextVerbPrepareLamba[Dialect <: Idiom, Naming <: NamingStrategy] extends ContextVerbPrepare[Dialect, Naming]:
+trait ContextVerbPrepareLambda[Dialect <: Idiom, Naming <: NamingStrategy] extends ContextVerbPrepare[Dialect, Naming]:
   self: Context[Dialect, Naming] =>
 
   type PrepareQueryResult = Session => Result[PrepareRow]
   type PrepareActionResult = Session => Result[PrepareRow]
   type PrepareBatchActionResult = Session => Result[List[PrepareRow]]
-end ContextVerbPrepareLamba
+end ContextVerbPrepareLambda


### PR DESCRIPTION
- Fix typo ContextVerbPrepareLamba -> ContextVerbPrepareLambda
- Remove redundant ExecutionInfo and replace with the one in Scala2-Quill's quill-engine module. Needed to refactor adding one more argument.