### PR TITLE
Working around semver and multi-inherit limitations in IntelliJ SCL-19345

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDsl.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDsl.scala
@@ -37,5 +37,5 @@ object UdtMeta:
         case None =>
           val typeName = TypeRepr.of[T].widen.typeSymbol.name
           // TODO quill.trace.types 'summoning' level should enable this
-          //println(s"MetaDsl not found. Making one with the type name: ${typeName}")
+          //println(s"Dsl not found. Making one with the type name: ${typeName}")
           UdtMetaDslMacro[T](Expr(typeName), Expr.ofList(Seq()))

--- a/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample1_Joes.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample1_Joes.scala
@@ -2,10 +2,10 @@ package io.getquill.examples
 
 import scala.language.implicitConversions
 import io.getquill._
-import io.getquill.QueryDsl._
+
 
 object MiniExample1_Joes {
-  
+
   case class Person(name: String, age: Int)
 
 

--- a/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample2_LiftOrAny.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample2_LiftOrAny.scala
@@ -2,10 +2,10 @@ package io.getquill.examples
 
 import scala.language.implicitConversions
 import io.getquill._
-import io.getquill.QueryDsl._
+
 
 object MiniExample2_LiftOrAny {
-  
+
   case class Person(name: String, age: Int)
 
   val ctx = new MirrorContext(MirrorSqlDialect, Literal)

--- a/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample3_InlineFilter.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample3_InlineFilter.scala
@@ -2,10 +2,10 @@ package io.getquill.examples
 
 import scala.language.implicitConversions
 import io.getquill._
-import io.getquill.QueryDsl._
+
 
 object MiniExample3_InlineFilter {
-  
+
   case class Person(name: String, age: Int)
 
   def main(args: Array[String]): Unit = {
@@ -13,9 +13,9 @@ object MiniExample3_InlineFilter {
     val ctx = new MirrorContext(MirrorSqlDialect, Literal)
     import ctx._
 
-    inline def onlyJoes = 
+    inline def onlyJoes =
       (p: Person) => p.name == "Joe"
-    
+
     inline def q = quote {
       query[Person].filter(onlyJoes)
     }

--- a/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample_LiftByKeys.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample_LiftByKeys.scala
@@ -3,7 +3,7 @@ package io.getquill.examples
 import scala.language.implicitConversions
 import io.getquill._
 import scala.compiletime.{erasedValue, summonFrom, constValue}
-import io.getquill.QueryDsl._
+
 import java.sql.Connection
 
 object MiniExample_LiftByKeys {

--- a/quill-sql/src/main/scala/io/getquill/Dsl.scala
+++ b/quill-sql/src/main/scala/io/getquill/Dsl.scala
@@ -26,15 +26,13 @@ import io.getquill.context.LiftMacro
 import io.getquill._
 import io.getquill.dsl.InfixDsl
 import io.getquill.context.StaticSpliceMacro
+import scala.language.implicitConversions
 
 implicit val defaultParser: ParserLibrary = ParserLibrary
 
 object Dsl extends Dsl // BaseParserFactory.type doesn't seem to work with the LoadModule used in quoteImpl
 
-trait Dsl extends QuoteDsl with QueryDsl with MetaDsl
-
-trait MetaDsl extends QueryDsl {
-
+trait Dsl {
   inline def schemaMeta[T](inline entity: String, inline columns: (T => (Any, String))*): SchemaMeta[T] =
     ${ SchemaMetaMacro[T]('this, 'entity, 'columns) }
 
@@ -43,15 +41,11 @@ trait MetaDsl extends QueryDsl {
 
   /** Automatic implicit ordering DSL for: `query[Person].sortBy(_.field)(<here>)` */
   implicit def implicitOrd[T]: Ord[T] = Ord.ascNullsFirst
-}
 
-object QueryDsl {
   extension (str: String) {
     def like(other: String): Boolean = ???
   }
-}
 
-trait QueryDsl {
   inline def query[T]: EntityQuery[T] = ${ QueryMacro[T] }
   inline def select[T]: Query[T] = ${ QueryMacro[T] }
 
@@ -70,10 +64,6 @@ trait QueryDsl {
           case (a: Option[_], b)            => a.exists(av => av != b)
           case (a, b: Option[_])            => b.exists(bv => bv != a)
           case (a, b)                       => a != b
-}
-
-trait QuoteDsl {
-  import scala.language.implicitConversions
 
   inline def static[T](inline value: T): T = ${ StaticSpliceMacro('value) }
 

--- a/quill-sql/src/main/scala/io/getquill/context/QueryMetaMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/QueryMetaMacro.scala
@@ -3,10 +3,10 @@ package io.getquill.context
 import scala.quoted._
 import io.getquill.parser.ParserFactory
 import io.getquill._
-import io.getquill.MetaDsl
+import io.getquill.Dsl
 
 object QueryMetaMacro {
-  def embed[T: Type, R: Type](qm: Expr[MetaDsl], expand: Expr[Quoted[Query[T] => Query[R]]], extract: Expr[R => T])(using Quotes): Expr[QueryMeta[T, R]] = {
+  def embed[T: Type, R: Type](qm: Expr[Dsl], expand: Expr[Quoted[Query[T] => Query[R]]], extract: Expr[R => T])(using Quotes): Expr[QueryMeta[T, R]] = {
     val uuid = Expr(java.util.UUID.randomUUID().toString)
     '{ QueryMeta[T, R]($expand, $uuid, $extract) }
   }

--- a/quill-sql/src/main/scala/io/getquill/context/SchemaMetaMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/SchemaMetaMacro.scala
@@ -2,7 +2,7 @@ package io.getquill.context
 
 import scala.quoted._
 import io.getquill.metaprog.Extractors._
-import io.getquill.MetaDsl
+import io.getquill.Dsl
 import io.getquill.SchemaMeta
 import io.getquill.Unquote
 import io.getquill.util.Load
@@ -12,7 +12,7 @@ object SchemaMetaMacro {
 
   // inline def schemaMeta[T](inline entity: String, inline columns: (T => (Any, String))*): SchemaMeta[T] =
   // SchemaMeta(quote { querySchema[T](entity, columns: _*) }, "1234") // TODO Don't need to generate a UID here.It can be static.
-  def apply[T](qm: Expr[MetaDsl], entity: Expr[String], columns: Expr[Seq[(T => (Any, String))]])(using Quotes, Type[T]): Expr[SchemaMeta[T]] = {
+  def apply[T](qm: Expr[Dsl], entity: Expr[String], columns: Expr[Seq[(T => (Any, String))]])(using Quotes, Type[T]): Expr[SchemaMeta[T]] = {
     val uuid = Expr(java.util.UUID.randomUUID().toString)
     val exprs =
       (columns match {

--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -9,7 +9,6 @@ import scala.annotation.StaticAnnotation
 import scala.deriving._
 import io.getquill.Embedable
 import io.getquill.Dsl
-import io.getquill.QueryDsl
 import scala.reflect.ClassTag
 import io.getquill.norm.capture.AvoidAliasConflict
 import io.getquill.metaprog.QuotationLotExpr
@@ -25,7 +24,7 @@ import io.getquill.metaprog.Pointable
 import io.getquill.metaprog.Extractors._
 import io.getquill.util.printer
 import io.getquill._
-import io.getquill.MetaDsl
+import io.getquill.Dsl
 import io.getquill.Ord
 import io.getquill.Embedded
 import io.getquill.metaprog.Is
@@ -201,8 +200,8 @@ class OrderingParser(val rootParse: Parser)(using Quotes) extends Parser(rootPar
   import quotes.reflect._
 
   def attempt: History ?=> PartialFunction[Expr[_], Ordering] = {
-    case '{ ($ordDsl: MetaDsl).implicitOrd } => AscNullsFirst
-    case '{ implicitOrd }                    => AscNullsFirst
+    case '{ ($ordDsl: Dsl).implicitOrd } => AscNullsFirst
+    case '{ implicitOrd }                => AscNullsFirst
 
     // Doing this on a lower level since there are multiple cases of Order.apply with multiple arguemnts
     case Unseal(Apply(TypeApply(Select(Ident("Ord"), "apply"), _), args)) =>
@@ -711,8 +710,10 @@ class ExtrasParser(val rootParse: Parser)(using Quotes) extends Parser(rootParse
 
 class OperationsParser(val rootParse: Parser)(using Quotes) extends Parser(rootParse) with ComparisonTechniques {
   import quotes.reflect._
-  import QueryDsl._
   import io.getquill.ast.Infix
+  // Note that if we import Dsl._ here then the "like" construct
+  // will be parsed from the Dsl.extensions as opposed to the exported ones?
+  // need to look into potential differences in these imports.
 
   // Handles named operations, ie Argument Operation Argument
   object NamedOp1 {

--- a/quill-sql/src/test/scala/io/getquill/MiniQuillTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/MiniQuillTest.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import scala.language.implicitConversions
 //
-//import io.getquill.QueryDsl._
+//
 //import io.getquill.SchemaMeta
 //import io.getquill.QueryMeta
 //import io.getquill.InsertMeta

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers._
 import org.scalatest._
 import io.getquill.quat._
-import io.getquill.QueryDsl._
+
 import io.getquill._
 
 object TestEnum:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.16.4.Beta2.7-SNAPSHOT"
+version in ThisBuild := "3.16.4-Beta2.7-SNAPSHOT"


### PR DESCRIPTION
Working around semver and multi-inherit limitations in IntelliJ SCL-19345.
Based on this:
https://youtrack.jetbrains.com/issue/SCL-19345/Scala-3-exported-macro-signatures-have-no-type-information-tasty#focus=Comments-27-6052957.0-0
...and this:
https://youtrack.jetbrains.com/issue/SCL-19345/Scala-3-exported-macro-signatures-have-no-type-information-tasty#focus=Comments-27-6053417.0-0