### PR TITLE
Fix Batch Insertion/Update for tuple-based fields

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/generic/TupleMember.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/TupleMember.scala
@@ -1,0 +1,41 @@
+package io.getquill.generic
+
+import scala.quoted._
+
+// object ZeroArgsMethod:
+//    def unapply()
+
+object TupleMember:
+  inline def apply[T](inline matchMember: String): Unit = ${ impl[T]('matchMember) }
+  def impl[T: Type](matchMemberExpr: Expr[String])(using Quotes): Expr[Unit] =
+    import quotes.reflect._
+    val matchMember =
+      matchMemberExpr match
+        case Expr(str) => str
+        case _         => report.throwError("Not a static string")
+
+    sealed trait ElaboratedField
+    object ElaboratedField:
+      def apply(tpe: TypeRepr, fieldName: String) =
+        val typeSymbol = tpe.typeSymbol
+        typeSymbol.methodMembers.find(m => m.name == fieldName && m.paramSymss == List()).map(ZeroArgsMethod(_))
+          .orElse(typeSymbol.fieldMembers.find(m => m.name == fieldName).map(Field(_)))
+          .getOrElse(NotFound)
+
+      case class ZeroArgsMethod(symbol: Symbol) extends ElaboratedField
+      case class Field(symbol: Symbol) extends ElaboratedField
+      case object NotFound extends ElaboratedField
+    end ElaboratedField
+
+    val clsType = TypeRepr.of[T]
+    // val memberSymbol = clsType.widen.classSymbol.get.memberField("_1")
+    // val memberSymbol = clsType.widen.typeSymbol.memberField("_1")
+    // val memberSymbol = clsType.typeSymbol.memberField("_1")
+    // val memberSymbol = clsType.typeSymbol.fieldMember("_1")
+    val elab = ElaboratedField(clsType, matchMember)
+    elab match
+      case ElaboratedField.ZeroArgsMethod(sym) => report.info(s"${sym} is a zero-args member whose type is ${clsType.widen.memberType(sym).widen}")
+      case ElaboratedField.Field(sym)          => report.info(s"${sym} is a field whose type is ${clsType.widen.memberType(sym).widen}")
+      case ElaboratedField.NotFound            => report.info(s"${matchMember} was not found")
+
+    '{ () }

--- a/quill-sql/src/main/scala/io/getquill/generic/TupleMemberUse.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/TupleMemberUse.scala
@@ -1,0 +1,8 @@
+package io.getquill.generic
+
+object TupleMemberUse {
+  TupleMember[(1, 2)]("_1") // // // //
+
+  case class Person(name: String, age: Int)
+  TupleMember[Person]("name")
+}

--- a/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
@@ -172,17 +172,17 @@ object Extractors {
   }
 
   extension (expr: Expr[_]) {
-    def `.`(property: String)(using Quotes) = {
+    def `.(caseField)`(property: String)(using Quotes) = {
       import quotes.reflect._
       val cls =
         expr.asTerm.tpe.widen.classSymbol.getOrElse {
           report.throwError(s"Cannot find class symbol of the property ${expr.show}", expr)
         }
       val method =
-        cls.memberFields // using memberFields might be more efficient but with it we have no control over the error messages since if method doesn't exist, exception is thrown right away
+        cls.caseFields
           .find(sym => sym.name == property)
           .getOrElse {
-            report.throwError(s"Cannot find property '${property}' of (${expr.show}:${cls.name}) fields are: ${cls.memberFields.map(_.name)}", expr)
+            report.throwError(s"Cannot find property '${property}' of (${expr.show}:${cls.name}) fields are: ${cls.caseFields.map(_.name)}", expr)
           }
 
       '{ (${ Select(expr.asTerm, method).asExpr }) }


### PR DESCRIPTION
Allowing tuple-based batch queries.

```scala
    "update via tuple" in {
      val birthYearUpdates = List((3431, 1983), (2976, 1972), (1511, 1991))
      val a = ctx.run {
        liftQuery(birthYearUpdates).foreach {
          case (id, year) =>
            query[MyPerson].filter(p => p.id == id).update(p => p.birthYear -> year)
        }
      }
      a.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)

      val b = ctx.run {
        liftQuery(birthYearUpdates).foreach((id, year) =>
          query[MyPerson].filter(p => p.id == id).update(p => p.birthYear -> year)
        )
      }
      b.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)
    }
```

Used to fail in `TypeRepr.memberType` NoDenotations owner because of how `memberType` was used.