### PR TITLE
Bump upstream to 3.18.0. Incorporating many fixes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,8 +138,8 @@ lazy val `quill-sql` =
         // errors will happen. Even if the pprint classes are actually there
         "io.suzaku" %% "boopickle" % "1.4.0",
         ("com.lihaoyi" %% "pprint" % "0.6.6"),
-        ("io.getquill" %% "quill-engine" % "3.16.5").excludeAll(ExclusionRule(organization = "com.twitter")),
-        ("io.getquill" %% "quill-util" % "3.16.5")
+        ("io.getquill" %% "quill-engine" % "3.18.0").excludeAll(ExclusionRule(organization = "com.twitter")),
+        ("io.getquill" %% "quill-util" % "3.18.0")
           .excludeAll({
             if (isCommunityBuild)
               Seq(ExclusionRule(organization = "org.scalameta", name = "scalafmt-core_2.13"))

--- a/quill-sql-tests/src/test/scala/io/getquill/InsertAdvancedSpec.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/InsertAdvancedSpec.scala
@@ -127,8 +127,8 @@ class InsertAdvancedSpec extends Spec with Inside {
         inline def a = quote { query[Person].filter(e => e.name == "JoeJoe").update(_.name -> "Joe", _.age -> 123) }
         inline given personSchema: UpdateMeta[Person] = updateMeta[Person](_.age)
         inline given sm: SchemaMeta[Person] = schemaMeta("tblPerson", _.name -> "colName", _.age -> "colAge")
-        ctx.run(q).triple mustEqual ("UPDATE tblPerson SET colName = ? WHERE colName = 'JoeJoe'", List("Joe"), Static)
-        ctx.run(a).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe', colAge = 123 WHERE colName = 'JoeJoe'", List(), Static)
+        ctx.run(q).triple mustEqual ("UPDATE tblPerson AS e SET colName = ? WHERE e.colName = 'JoeJoe'", List("Joe"), Static)
+        ctx.run(a).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe', colAge = 123 WHERE e.colName = 'JoeJoe'", List(), Static)
       }
 
       "simple with schemaMeta with extra columns and update meta fully lifted with filter lift" in {
@@ -136,8 +136,8 @@ class InsertAdvancedSpec extends Spec with Inside {
         inline def a = quote { query[Person].filter(e => e.name == lift("JoeJoe")).update(_.name -> "Joe", _.age -> 123) }
         inline given personSchema: UpdateMeta[Person] = updateMeta[Person](_.age)
         inline given sm: SchemaMeta[Person] = schemaMeta("tblPerson", _.name -> "colName", _.age -> "colAge")
-        ctx.run(q).triple mustEqual ("UPDATE tblPerson SET colName = ? WHERE colName = ?", List("Joe", "JoeJoe"), Static)
-        ctx.run(a).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe', colAge = 123 WHERE colName = ?", List("JoeJoe"), Static)
+        ctx.run(q).triple mustEqual ("UPDATE tblPerson AS e SET colName = ? WHERE e.colName = ?", List("Joe", "JoeJoe"), Static)
+        ctx.run(a).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe', colAge = 123 WHERE e.colName = ?", List("JoeJoe"), Static)
       }
 
       "simple with schemaMeta with extra columns and update meta filter lift - included column" in {
@@ -145,8 +145,8 @@ class InsertAdvancedSpec extends Spec with Inside {
         inline def a = quote { query[Person].filter(e => e.name == lift("JoeJoe")).update(_.name -> lift("Joe"), _.age -> 123) }
         inline given personSchema: UpdateMeta[Person] = updateMeta[Person](_.age)
         inline given sm: SchemaMeta[Person] = schemaMeta("tblPerson", _.name -> "colName", _.age -> "colAge")
-        ctx.run(q).triple mustEqual ("UPDATE tblPerson SET colName = ? WHERE colName = ?", List("Joe", "JoeJoe"), Static)
-        ctx.run(a).triple mustEqual ("UPDATE tblPerson SET colName = ?, colAge = 123 WHERE colName = ?", List("Joe", "JoeJoe"), Static)
+        ctx.run(q).triple mustEqual ("UPDATE tblPerson AS e SET colName = ? WHERE e.colName = ?", List("Joe", "JoeJoe"), Static)
+        ctx.run(a).triple mustEqual ("UPDATE tblPerson AS e SET colName = ?, colAge = 123 WHERE e.colName = ?", List("Joe", "JoeJoe"), Static)
       }
 
       "simple with schemaMeta with extra columns and update meta filter lift - excluded column" in {
@@ -154,8 +154,8 @@ class InsertAdvancedSpec extends Spec with Inside {
         inline def a = quote { query[Person].filter(e => e.name == lift("JoeJoe")).update(_.name -> "Joe", _.age -> lift(123)) }
         inline given personSchema: UpdateMeta[Person] = updateMeta[Person](_.age)
         inline given sm: SchemaMeta[Person] = schemaMeta("tblPerson", _.name -> "colName", _.age -> "colAge")
-        ctx.run(q).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe' WHERE colName = ?", List("JoeJoe"), Static)
-        ctx.run(a).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe', colAge = ? WHERE colName = ?", List(123, "JoeJoe"), Static)
+        ctx.run(q).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe' WHERE e.colName = ?", List("JoeJoe"), Static)
+        ctx.run(a).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe', colAge = ? WHERE e.colName = ?", List(123, "JoeJoe"), Static)
       }
 
       "simple with schemaMeta with extra columns and update meta filter lift - filter by excluded column" in {
@@ -163,8 +163,8 @@ class InsertAdvancedSpec extends Spec with Inside {
         inline def a = quote { query[Person].filter(e => e.age == lift(123)).update(_.name -> "Joe", _.age -> lift(123)) }
         inline given personSchema: UpdateMeta[Person] = updateMeta[Person](_.age)
         inline given sm: SchemaMeta[Person] = schemaMeta("tblPerson", _.name -> "colName", _.age -> "colAge")
-        ctx.run(q).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe' WHERE colAge = ?", List(123), Static)
-        ctx.run(a).triple mustEqual ("UPDATE tblPerson SET colName = 'Joe', colAge = ? WHERE colAge = ?", List(123, 123), Static)
+        ctx.run(q).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe' WHERE e.colAge = ?", List(123), Static)
+        ctx.run(a).triple mustEqual ("UPDATE tblPerson AS e SET colName = 'Joe', colAge = ? WHERE e.colAge = ?", List(123, 123), Static)
       }
     }
 

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/ActionSpec.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/ActionSpec.scala
@@ -132,21 +132,21 @@ class ActionSpec extends Spec {
           qr1.filter(t => t.s == "s").updateValue(TestEntity("s", 1, 2L, Some(1), true))
         }
         testContext.run(q).string mustEqual
-          "UPDATE TestEntity SET s = 's', i = 1, l = 2, o = 1, b = true WHERE s = 's'"
+          "UPDATE TestEntity AS t SET s = 's', i = 1, l = 2, o = 1, b = true WHERE t.s = 's'"
       }
       "entity with filter" in {
         inline def q = quote {
           qr1.filter(t => t.s == "s").updateValue(TestEntity("s", 1, 2L, Some(1), true))
         }
         testContext.run(q).string mustEqual
-          "UPDATE TestEntity SET s = 's', i = 1, l = 2, o = 1, b = true WHERE s = 's'"
+          "UPDATE TestEntity AS t SET s = 's', i = 1, l = 2, o = 1, b = true WHERE t.s = 's'"
       }
       "entity with filter and lift" in {
         inline def q = quote {
           qr1.filter(t => t.s == lift("s")).updateValue(TestEntity("s", 1, 2L, Some(1), true))
         }
         testContext.run(q).triple mustEqual
-          ("UPDATE TestEntity SET s = 's', i = 1, l = 2, o = 1, b = true WHERE s = ?", List("s"), Static)
+          ("UPDATE TestEntity AS t SET s = 's', i = 1, l = 2, o = 1, b = true WHERE t.s = ?", List("s"), Static)
       }
     }
     "updateValue" - {
@@ -157,7 +157,7 @@ class ActionSpec extends Spec {
         }
         val result = testContext.run(q)
         result.triple mustEqual
-          ("UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE s = 's'", List("s", 1, 2L, Some(1), true), Static)
+          ("UPDATE TestEntity AS t SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE t.s = 's'", List("s", 1, 2L, Some(1), true), Static)
       }
       "with filter and lift" in {
         inline def q = quote {
@@ -165,7 +165,7 @@ class ActionSpec extends Spec {
         }
         val result = testContext.run(q)
         result.triple mustEqual
-          ("UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE s = ?", List("s", 1, 2L, Some(1), true, "s"), Static)
+          ("UPDATE TestEntity AS t SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE t.s = ?", List("s", 1, 2L, Some(1), true, "s"), Static)
       }
       "quoted with filter and lift" in {
         inline def orig = quote {
@@ -176,7 +176,7 @@ class ActionSpec extends Spec {
         }
         val result = testContext.run(q)
         result.triple mustEqual
-          ("UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE s = ?", List("s", 1, 2L, Some(1), true, "s"), Static)
+          ("UPDATE TestEntity AS t SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE t.s = ?", List("s", 1, 2L, Some(1), true, "s"), Static)
       }
       "quoted dynamic with filter and lift" in {
         val orig = quote {
@@ -187,7 +187,7 @@ class ActionSpec extends Spec {
         }
         val result = testContext.run(q)
         result.triple mustEqual
-          ("UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE s = ?", List("s", 1, 2L, Some(1), true, "s"), Dynamic)
+          ("UPDATE TestEntity AS t SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE t.s = ?", List("s", 1, 2L, Some(1), true, "s"), Dynamic)
       }
       "fully dynamic with filter and lift" in {
         val orig = quote {
@@ -197,7 +197,7 @@ class ActionSpec extends Spec {
           orig.updateValue(lift(v))
         }
         testContext.run(q).triple mustEqual
-          ("UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE s = ?", List("s", 1, 2L, Some(1), true, "s"), Dynamic)
+          ("UPDATE TestEntity AS t SET s = ?, i = ?, l = ?, o = ?, b = ? WHERE t.s = ?", List("s", 1, 2L, Some(1), true, "s"), Dynamic)
       }
     }
     "update" - {
@@ -206,14 +206,14 @@ class ActionSpec extends Spec {
           qr1.filter(t => t.s == null).update(_.s -> "s")
         }
         testContext.run(q).string mustEqual
-          "UPDATE TestEntity SET s = 's' WHERE s IS NULL"
+          "UPDATE TestEntity AS t SET s = 's' WHERE t.s IS NULL"
       }
       "with filter" in {
         inline def q = quote {
           qr1.filter(t => t.s == "s").update(_.s -> "s")
         }
         testContext.run(q).string mustEqual
-          "UPDATE TestEntity SET s = 's' WHERE s = 's'"
+          "UPDATE TestEntity AS t SET s = 's' WHERE t.s = 's'"
       }
       "with filter and lift" in {
         inline def q = quote {
@@ -221,7 +221,7 @@ class ActionSpec extends Spec {
         }
         val result = testContext.run(q)
         result.triple mustEqual
-          ("UPDATE TestEntity SET s = 's' WHERE s = ?", List("s"), Static)
+          ("UPDATE TestEntity AS t SET s = 's' WHERE t.s = ?", List("s"), Static)
       }
       "without filter" in {
         val q = quote {
@@ -251,7 +251,7 @@ class ActionSpec extends Spec {
           qr1.filter(t => t.s == null).delete
         }
         testContext.run(q).string mustEqual
-          "DELETE FROM TestEntity WHERE s IS NULL"
+          "DELETE FROM TestEntity AS t WHERE t.s IS NULL"
       }
       "without filter" in {
         val q = quote {

--- a/quill-sql/src/main/scala/io/getquill/metaprog/ExprAccumulate.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/ExprAccumulate.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable.ArrayBuffer
 import io.getquill.util.Format
 import scala.util.Try
 
-/** Remove all instances of SerialHelper.fromSerializedJVM from a tree (for printing purposes) */
+/** Remove all instances of SerialHelper.fromSerialized from a tree (for printing purposes) */
 object DeserializeAstInstances:
   def apply[T: Type](input: Expr[T])(using Quotes): Expr[T] = {
     import quotes.reflect.{Try => _, _}

--- a/quill-sql/src/test/scala/io/getquill/BatchActionTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/BatchActionTest.scala
@@ -57,7 +57,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
     // update returning with filter, not very useful but good baseline
     "update - returning" in {
       val mirror = ctx.run { liftQuery(people).foreach(p => query[Person].filter(pf => pf.id == p.id).updateValue(p).returning(p => p.id)) }
-      mirror.triple mustEqual ("UPDATE Person SET id = ?, name = ?, age = ? WHERE id = ? RETURNING id", List(List(1, "Joe", 123, 1), List(2, "Jill", 456, 2)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS pf SET id = ?, name = ?, age = ? WHERE pf.id = ? RETURNING id", List(List(1, "Joe", 123, 1), List(2, "Jill", 456, 2)), Static)
     }
 
     // TODO dsl does not support this yet but would be quite useful
@@ -90,7 +90,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
 
     "update - liftQuery scalars" in {
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => query[Person].filter(p => p.id == i).update(_.age -> 111)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = 111 WHERE id = ?", List(List(1), List(2), List(3)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = 111 WHERE p.id = ?", List(List(1), List(2), List(3)), Static)
     }
 
     "update - liftQuery scalars - dynamic" in {
@@ -98,7 +98,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (i: Int) => query[Person].filter(p => p.id == i).update(_.age -> 111)
       }
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => updateDynamic(i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = 111 WHERE id = ?", List(List(1), List(2), List(3)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = 111 WHERE p.id = ?", List(List(1), List(2), List(3)), Dynamic)
     }
 
     "update - extra lift" in {
@@ -106,27 +106,27 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
       // val mirror = ctx.run { query[Person].filter(p => p.id == 123).insertValue(people(0)) }
       //
       val mirror = ctx.run { liftQuery(people).foreach(p => query[Person].filter(p => p.id == lift(36)).updateValue(p)) }
-      mirror.triple mustEqual ("UPDATE Person SET id = ?, name = ?, age = ? WHERE id = ?", List(List(1, "Joe", 123, 36), List(2, "Jill", 456, 36)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET id = ?, name = ?, age = ? WHERE p.id = ?", List(List(1, "Joe", 123, 36), List(2, "Jill", 456, 36)), Static)
     }
 
     "update - extra lift + scalars" in {
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => query[Person].filter(p => p.id == lift(36)).update(_.age -> i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id = ?", List(List(1, 36), List(2, 36), List(3, 36)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id = ?", List(List(1, 36), List(2, 36), List(3, 36)), Static)
     }
 
     "update - extra lift + scalars + multi-use" in {
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => query[Person].filter(p => p.id == i && p.age == lift(123)).update(_.age -> i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id = ? AND age = ?", List(List(1, 1, 123), List(2, 2, 123), List(3, 3, 123)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id = ? AND p.age = ?", List(List(1, 1, 123), List(2, 2, 123), List(3, 3, 123)), Static)
     }
 
     "update - extra lift + scalars + liftQuery/setContains" in {
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => query[Person].filter(p => liftQuery(List(36, 49)).contains(p.id)).update(_.age -> i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id IN (?, ?)", List(List(1, 36, 49), List(2, 36, 49), List(3, 36, 49)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id IN (?, ?)", List(List(1, 36, 49), List(2, 36, 49), List(3, 36, 49)), Static)
     }
 
     "update - extra lift + scalars + liftQuery/setContains + others" in {
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => query[Person].filter(p => liftQuery(List(36, 49)).contains(p.id) && p.id == lift(789)).update(_.age -> i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id IN (?, ?) AND id = ?", List(List(1, 36, 49, 789), List(2, 36, 49, 789), List(3, 36, 49, 789)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id IN (?, ?) AND p.id = ?", List(List(1, 36, 49, 789), List(2, 36, 49, 789), List(3, 36, 49, 789)), Static)
     }
 
     "update - extra lift - dynamic" in {
@@ -134,7 +134,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (p: Person) => query[Person].filter(p => p.id == lift(36)).updateValue(p)
       }
       val mirror = ctx.run { liftQuery(people).foreach(p => updateDynamic(p)) }
-      mirror.triple mustEqual ("UPDATE Person SET id = ?, name = ?, age = ? WHERE id = ?", List(List(1, "Joe", 123, 36), List(2, "Jill", 456, 36)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET id = ?, name = ?, age = ? WHERE p.id = ?", List(List(1, "Joe", 123, 36), List(2, "Jill", 456, 36)), Dynamic)
     }
 
     "update - extra lift - dynamic + scalars" in {
@@ -142,7 +142,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (i: Int) => query[Person].filter(p => p.id == lift(36)).update(_.age -> i)
       }
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => updateDynamic(i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id = ?", List(List(1, 36), List(2, 36), List(3, 36)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id = ?", List(List(1, 36), List(2, 36), List(3, 36)), Dynamic)
     }
 
     "update - extra lift - dynamic + scalars + multi-use" in {
@@ -150,7 +150,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (i: Int) => query[Person].filter(p => p.id == i && p.age == lift(123)).update(_.age -> i)
       }
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => updateDynamic(i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id = ? AND age = ?", List(List(1, 1, 123), List(2, 2, 123), List(3, 3, 123)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id = ? AND p.age = ?", List(List(1, 1, 123), List(2, 2, 123), List(3, 3, 123)), Dynamic)
     }
 
     "update - extra lift - dynamic + scalars + liftQuery/setContains" in {
@@ -158,7 +158,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (i: Int) => query[Person].filter(p => liftQuery(List(36, 49)).contains(p.id)).update(_.age -> i)
       }
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => updateDynamic(i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id IN (?, ?)", List(List(1, 36, 49), List(2, 36, 49), List(3, 36, 49)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id IN (?, ?)", List(List(1, 36, 49), List(2, 36, 49), List(3, 36, 49)), Dynamic)
     }
 
     "update - extra lift - dynamic + scalars + liftQuery/setContains + others" in {
@@ -166,7 +166,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
         (i: Int) => query[Person].filter(p => liftQuery(List(36, 49)).contains(p.id) && p.id == lift(789)).update(_.age -> i)
       }
       val mirror = ctx.run { liftQuery(List(1, 2, 3)).foreach(i => updateDynamic(i)) }
-      mirror.triple mustEqual ("UPDATE Person SET age = ? WHERE id IN (?, ?) AND id = ?", List(List(1, 36, 49, 789), List(2, 36, 49, 789), List(3, 36, 49, 789)), Dynamic)
+      mirror.triple mustEqual ("UPDATE Person AS p SET age = ? WHERE p.id IN (?, ?) AND p.id = ?", List(List(1, 36, 49, 789), List(2, 36, 49, 789), List(3, 36, 49, 789)), Dynamic)
     }
 
     case class MyPerson(id: Int, name: String, birthYear: Int)
@@ -178,14 +178,14 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
             query[MyPerson].filter(p => p.id == id).update(p => p.birthYear -> year)
         }
       }
-      a.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)
+      a.triple mustEqual ("UPDATE MyPerson AS p SET birthYear = ? WHERE p.id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)
 
       val b = ctx.run {
         liftQuery(birthYearUpdates).foreach((id, year) =>
           query[MyPerson].filter(p => p.id == id).update(p => p.birthYear -> year)
         )
       }
-      b.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)
+      b.triple mustEqual ("UPDATE MyPerson AS p SET birthYear = ? WHERE p.id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Static)
     }
 
     "update via tuple - dynamic" in {
@@ -199,12 +199,12 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
           case (id, year) => updateDynamic(id, year)
         }
       }
-      a.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Dynamic)
+      a.triple mustEqual ("UPDATE MyPerson AS p SET birthYear = ? WHERE p.id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Dynamic)
 
       val b = ctx.run {
         liftQuery(birthYearUpdates).foreach((id, year) => updateDynamic(id, year))
       }
-      b.triple mustEqual ("UPDATE MyPerson SET birthYear = ? WHERE id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Dynamic)
+      b.triple mustEqual ("UPDATE MyPerson AS p SET birthYear = ? WHERE p.id = ?", List(List(1983, 3431), List(1972, 2976), List(1991, 1511)), Dynamic)
 
       // Does not work, variable tracking has an issue
       // val b = ctx.run {
@@ -225,14 +225,14 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
 
     "update" in {
       val mirror = ctx.run { liftQuery(people).foreach(p => query[Person].filter(pf => pf.id == p.id).update(_.name -> p.name, _.age -> p.age)) }
-      mirror.triple mustEqual ("UPDATE Person SET name = ?, age = ? WHERE id = ?", List(List("Joe", 123, 1), List("Jill", 456, 2)), Static)
+      mirror.triple mustEqual ("UPDATE Person AS pf SET name = ?, age = ? WHERE pf.id = ?", List(List("Joe", 123, 1), List("Jill", 456, 2)), Static)
     }
 
     "update - object with meta" in {
       inline given UpdateMeta[Person] = updateMeta(_.id)
       val mirror = ctx.run { liftQuery(people).foreach(p => query[Person].filter(pf => pf.id == p.id).updateValue(p)) }
       mirror.triple mustEqual (
-        "UPDATE Person SET name = ?, age = ? WHERE id = ?",
+        "UPDATE Person AS pf SET name = ?, age = ? WHERE pf.id = ?",
         List(List("Joe", 123, 1), List("Jill", 456, 2)),
         Static
       )
@@ -240,7 +240,7 @@ class BatchActionTest extends Spec with Inside with SuperContext[PostgresDialect
 
     "delete" in {
       val mirror = ctx.run { liftQuery(people).foreach(p => query[Person].filter(pf => pf.id == p.id).delete) }
-      mirror.triple mustEqual ("DELETE FROM Person WHERE id = ?", List(List(1), List(2)), Static)
+      mirror.triple mustEqual ("DELETE FROM Person AS pf WHERE pf.id = ?", List(List(1), List(2)), Static)
     }
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -136,7 +136,7 @@ class QuatSpec extends AnyFreeSpec {
     import BooQuatSerializer._
     val example = Quat.Product("bv" -> Quat.BooleanValue, "be" -> Quat.BooleanExpression, "v" -> Quat.Value, "p" -> Quat.Product("vv" -> Quat.Value))
     "with boo" in {
-      Quat.fromSerializedJS(serialize(example)) mustEqual example
+      Quat.fromSerialized(serialize(example)) mustEqual example
     }
     // kryo tests are covered by standard JVM quill specs
   }


### PR DESCRIPTION
Bump to quill-engine/util 3.18.0.

Quite a few fixes were incorporated into dialects. See:
https://github.com/zio/zio-quill/blob/42ceeff0f81659070688157950ec827c06c9c6a6/CHANGELOG.md#3180