### PR TITLE
Implementing dynamic splices via #${splice} like Scala2-Quill

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/QuoteMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/QuoteMacro.scala
@@ -19,6 +19,9 @@ import io.getquill.parser.Unlifter
 import io.getquill.util.Format
 import io.getquill.norm.TranspileConfig
 import io.getquill.metaprog.SummonTranspileConfig
+import io.getquill.ast.Ast
+import io.getquill.ast.StatefulTransformer
+import io.getquill.QuotationVase
 
 object ExtractLifts {
   // Find all lifts, dedupe by UID since lifts can be inlined multiple times hence
@@ -63,6 +66,60 @@ object ExtractLifts {
 
 object QuoteMacro {
 
+  object DynamicsExtractor {
+    import io.getquill.ast.Dynamic
+    import io.getquill.ast.QuotationTag
+    import java.util.UUID
+    import io.getquill.metaprog.Extractors._
+
+    case class Extractee(uid: String, dynamic: Dynamic)
+    case class Transform(state: List[Extractee]) extends StatefulTransformer[List[Extractee]] {
+      override def apply(e: Ast): (Ast, StatefulTransformer[List[Extractee]]) =
+        e match
+          case dyn: Dynamic =>
+            val uid = UUID.randomUUID().toString()
+            (QuotationTag(uid), Transform(Extractee(uid, dyn) +: state))
+          case _ => super.apply(e)
+
+    }
+
+    def apply(ast: Ast)(using Quotes): (Ast, List[Expr[QuotationVase]]) = {
+      import quotes.reflect._
+
+      def printAstWithCustom(ast: Ast)(uid: String, replacementText: String) = {
+        import io.getquill.MirrorIdiom._
+        import io.getquill.idiom.StatementInterpolator._
+        import io.getquill.ast.External
+        implicit def externalTokenizer: Tokenizer[External] =
+          Tokenizer[External] {
+            case QuotationTag(tagUid) if (tagUid == uid) =>
+              replacementText.token
+            case _ => stmt"?"
+          }
+        ast.token.toString
+      }
+
+      val (newAst, transformer) = Transform(List())(ast)
+      val extracted = transformer.state.reverse
+      val quotations =
+        extracted.map {
+          case Extractee(uid, Dynamic(value, quat)) =>
+            val quotation =
+              value match
+                case expr: Expr[_] if (is[Quoted[_]](expr)) =>
+                  expr.asExprOf[Quoted[_]]
+                case expr: Expr[_] =>
+                  report.throwError(s"Dynamic value has invalid expression: ${Format.Expr(expr)} in the AST:\n${printAstWithCustom(newAst)(uid, "<INVALID-HERE>")}")
+                case other =>
+                  report.throwError(s"Dynamic value is not an expression: ${other} in the AST:\n${printAstWithCustom(newAst)(uid, "<INVALID-HERE>")}")
+
+            '{ QuotationVase($quotation, ${ Expr(uid) }) }
+        }
+
+      (newAst, quotations)
+    }
+  }
+
   def apply[T](bodyRaw: Expr[T])(using Quotes, Type[T], Type[Parser]): Expr[Quoted[T]] = {
     import quotes.reflect._
 
@@ -74,13 +131,14 @@ object QuoteMacro {
     given TranspileConfig = SummonTranspileConfig()
 
     val rawAst = parser(body)
-    val ast = SimplifyFilterTrue(BetaReduction(rawAst))
+    val (noDynamicsAst, dynamicQuotes) = DynamicsExtractor(rawAst)
+    val ast = SimplifyFilterTrue(BetaReduction(noDynamicsAst))
 
     val reifiedAst = Lifter.WithBehavior(serializeQuats, serializeAst)(ast)
     val u = Unlifter(reifiedAst)
 
     // Extract runtime quotes and lifts
     val (lifts, pluckedUnquotes) = ExtractLifts(bodyRaw)
-    '{ Quoted[T](${ reifiedAst }, ${ Expr.ofList(lifts) }, ${ Expr.ofList(pluckedUnquotes) }) }
+    '{ Quoted[T](${ reifiedAst }, ${ Expr.ofList(lifts) }, ${ Expr.ofList(pluckedUnquotes ++ dynamicQuotes) }) }
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
@@ -86,7 +86,7 @@ object ParserHelpers:
       end CheckTypes
 
       def OrFail(expr: Expr[_])(using Quotes, History) =
-        unapply(expr).getOrElse { ParserError(expr, classOf[Assignment]) }
+        unapply(expr).getOrElse { failParse(expr, classOf[Assignment]) }
 
       def unapply(expr: Expr[_])(using Quotes, History): Option[Assignment] =
         UntypeExpr(expr) match
@@ -96,7 +96,7 @@ object ParserHelpers:
 
       object Double:
         def OrFail(expr: Expr[_])(using Quotes, History) =
-          unapply(expr).getOrElse { ParserError(expr, classOf[AssignmentDual]) }
+          unapply(expr).getOrElse { failParse(expr, classOf[AssignmentDual]) }
         def unapply(expr: Expr[_])(using Quotes, History): Option[AssignmentDual] =
           UntypeExpr(expr) match
             case TwoComponents(ident1, identTpe1, ident2, identTpe2, prop, value) =>
@@ -169,7 +169,7 @@ object ParserHelpers:
     object PropertyAliasExpr {
       def OrFail[T: Type](expr: Expr[Any]) = expr match
         case PropertyAliasExpr(propAlias) => propAlias
-        case _                            => ParserError(expr, classOf[PropertyAlias])
+        case _                            => failParse(expr, classOf[PropertyAlias])
 
       def unapply[T: Type](expr: Expr[Any]): Option[PropertyAlias] =
         expr match

--- a/quill-sql/src/main/scala/io/getquill/parser/engine/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/engine/Parser.scala
@@ -7,7 +7,7 @@ import io.getquill.parser.ParserHelpers
 trait Parser(rootParse: Parser | Parser.Nil)(using Quotes):
   import quotes.reflect._
   def apply(input: Expr[_])(using History): Ast = attempt.lift(input).getOrElse(error(input))
-  protected def error(input: Expr[_]): Nothing = ParserError(input, classOf[Ast])
+  protected def error(input: Expr[_]): Nothing = failParse(input, classOf[Ast])
   protected def attempt: History ?=> PartialFunction[Expr[_], Ast]
   // Attempt the parser externally. Usually this is the just the `attempt` method
   // but in some cases we might want early-exist functionality.

--- a/quill-sql/src/main/scala/io/getquill/parser/engine/failParse.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/engine/failParse.scala
@@ -3,7 +3,7 @@ package io.getquill.parser.engine
 import scala.quoted._
 import io.getquill.util.Format
 
-object ParserError:
+object failParse:
   enum ThrowInfo:
     case AstClass(astClass: Class[_])
     case Message(msg: String)
@@ -36,4 +36,4 @@ object ParserError:
       expr
     )
   end apply
-end ParserError
+end failParse


### PR DESCRIPTION
This is the ProtoQuill equivalent of: https://github.com/zio/zio-quill/pull/1020
It uses a very similar pattern of detecting quote-parts that have a `#` at the end.
Unlike Scala2-Quill however, the resulting Quote is stored in the `runtimeQuotes` of the Quoted case class instead of the AST tree. Initially the parser puts into onto the AST tree but then it is extracted and replaced with a QuotationTag (the same as other runtime quotes). This way it fits perfectly into the ProtoQuill compile-time vs runtime paradigm and the ProtoQuill AST is still serializable from the beginning (i.e. from quotation onward vs Scala2-Quill which is not because it stores Dynamic and Lift values directly in the tree).