### PR TITLE
FilterByKeys needs to be placed before FilterColumns, examples fixed.

### DIFF
--- a/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
+++ b/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
@@ -37,8 +37,8 @@ object Dao:
     quote {
       query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
         .map((p, a) => PersonAddress(p.id, p.first, p.last, p.age, a.map(_.street)))
-        .filterColumns(columns)
         .filterByKeys(filters)
+        .filterColumns(columns)
         .take(10)
     }
   inline def plan(inline columns: List[String], inline filters: Map[String, String]) =

--- a/quill-caliban/src/test/scala/io/getquill/example/CalibanExampleNested.scala
+++ b/quill-caliban/src/test/scala/io/getquill/example/CalibanExampleNested.scala
@@ -36,8 +36,8 @@ object DaoNested:
     quote {
       query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
         .map((p, a) => PersonAddressNested(p.id, p.name, p.age, a.map(_.street)))
-        .filterColumns(columns)
         .filterByKeys(filters)
+        .filterColumns(columns)
         .take(10)
     }
   inline def plan(inline columns: List[String], inline filters: Map[String, String]) =


### PR DESCRIPTION
### Problem
    /**
     * When using this with FilterColumns make sure it comes FIRST. Otherwise the columns are you filtering
     * may have been nullified in the SQL before the filteration has actually happened.
     */
Examples show incorrect order of FilterByKeys and FilterColumns methods use. 


### Solution

Put FilterByKeys method before FilterColumns in examples.

@getquill/maintainers
