### PR TITLE
Fixing Caliban Datatype conversion issues

### DIFF
--- a/build/Dockerfile-mysql
+++ b/build/Dockerfile-mysql
@@ -1,0 +1,9 @@
+# Builds a ubuntu-based postgres image whose latency can be modified to be highe
+# for performance experimentation.
+FROM ubuntu/mysql:8.0-20.04_beta
+
+# Odd issue that needs to be fixed from here: https://stackoverflow.com/a/71982514
+RUN sed -i -e 's/^APT/# APT/' -e 's/^DPkg/# DPkg/' \
+      /etc/apt/apt.conf.d/docker-clean
+RUN apt-get update && \
+    apt-get install iproute2 iputils-ping -y

--- a/build/Dockerfile-sqlserver
+++ b/build/Dockerfile-sqlserver
@@ -1,0 +1,6 @@
+# Builds a ubuntu-based postgres image whose latency can be modified to be highe
+# for performance experimentation.
+FROM mcr.microsoft.com/mssql/server
+USER root
+RUN apt-get update && \
+    apt-get install iproute2 iputils-ping -y

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     - NET_ADMIN
 
   mysql:
-    image: mysql/mysql-server:8.0.23 # use this because it supports ARM64 architecture for M1 Mac
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile-mysql
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - "13306:3306"
@@ -22,6 +24,8 @@ services:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_ROOT_HOST=%
+    cap_add:
+    - NET_ADMIN
 
   cassandra:
     build:
@@ -47,12 +51,16 @@ services:
     init: true
 
   sqlserver:
-    image: mcr.microsoft.com/mssql/server
+    build:
+        context: .
+        dockerfile: ./build/Dockerfile-sqlserver
     ports:
       - "11433:1433"
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=QuillRocks!
+    cap_add:
+    - NET_ADMIN
 
   oracle:
     image: quillbuilduser/oracle-18-xe-micro-sq
@@ -72,6 +80,7 @@ services:
       - postgres:postgres
       - mysql:mysql
       - cassandra:cassandra
+      - docker_ping:docker_ping
       #- orientdb:orientdb
       - sqlserver:sqlserver
       - oracle:oracle
@@ -83,13 +92,13 @@ services:
   # If you need to double-check the postgres docker image has
   # a set amount of network latency (that can be set by increase_postgres_latency.sh)
   # then uncomment to start.
-  # docker_ping:
-  #   build:
-  #     context: .
-  #     dockerfile: ./build/Dockerfile-ping
-  #   container_name: docker_ping
-  #   command: >
-  #     ping postgres
+  docker_ping:
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile-ping
+    container_name: docker_ping
+    command: >
+      ping sqlserver
 
   sbt:
     build:
@@ -103,6 +112,7 @@ services:
       - mysql:mysql
       #- cassandra:cassandra
       #- orientdb:orientdb
+      - docker_ping:docker_ping
       - sqlserver:sqlserver
       - oracle:oracle
     volumes:

--- a/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationSpec.scala
+++ b/quill-caliban/src/test/scala/io/getquill/CalibanIntegrationSpec.scala
@@ -16,12 +16,6 @@ class CalibanIntegrationSpec extends CalibanSpec {
     import FlatSchema._
     object Dao:
       def personAddress(columns: List[String], filters: Map[String, String]): ZIO[Any, Throwable, List[PersonAddress]] =
-        io.getquill.util.debug.PrintMac {
-          query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
-            .map((p, a) => PersonAddress(p.id, p.first, p.last, p.age, a.map(_.street)))
-            .filterByKeys(filters)
-        }
-
         Ctx.run {
           query[PersonT].leftJoin(query[AddressT]).on((p, a) => p.id == a.ownerId)
             .map((p, a) => PersonAddress(p.id, p.first, p.last, p.age, a.map(_.street)))
@@ -42,7 +36,6 @@ class CalibanIntegrationSpec extends CalibanSpec {
         Queries(
           personAddressFlat =>
             (productArgs =>
-              println(s"============ Using Filters: ${pprint.apply(productArgs.keyValues)}")
               Flat.Dao.personAddress(quillColumns(personAddressFlat), productArgs.keyValues)
             )
         )
@@ -85,6 +78,6 @@ class CalibanIntegrationSpec extends CalibanSpec {
           }
         }"""
       unsafeRunQuery(query) mustEqual """{"personAddressFlat":[{"id":1,"last":"A","street":"123 St"}]}"""
-    } //
+    }
   }
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -46,7 +46,7 @@ trait Encoders extends EncodingDsl {
       (index, value, row, session) =>
         value match {
           case Some(v) => d.encoder(index, v, row, session)
-          case None    => integerBasedNullEncoder.encoder(index, d.sqlType, row, session)
+          case None    => encoder(d.sqlType, (i, v, r) => r.setNull(index, d.sqlType))(index, 0, row, session)
         }
     )
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/BatchValuesJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/BatchValuesJdbcSpec.scala
@@ -31,4 +31,5 @@ class BatchValuesJdbcSpec extends BatchValuesSpec {
     testContext.run(op, batchSize)
     testContext.run(get).toSet mustEqual result.toSet
   }
+  
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
@@ -1,0 +1,84 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill._
+import org.scalatest.Inside
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.ZoneId
+
+object FlicerMapTypesSpec {
+  // Need to define here since AnyVal class cannot be local
+  object `Should succeed with AnyValue`:
+    case class Info(value: String) extends AnyVal
+    case class ContactComplex(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: Info)
+}
+
+class FlicerMapTypesSpec extends Spec with Inside {
+  val ctx = testContext
+  import ctx._
+
+  case class Contact(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
+  val contacts = List(
+    Contact("Joe", "Bloggs", 123, 1, "1"),
+    Contact("Joe", "Noggs", 123, 1, "1"),
+    Contact("Jim", "Roogs", 111, 2, "2")
+  )
+  case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDateTime)
+  def makeEntity(i: Int) = {
+    val ld = LocalDate.of(2022, i, i)
+    val ldt = LocalDateTime.of(2022, i, i, i, i, i)
+    DateEncodingTestEntity(ld, ldt)
+  }
+  val dates = List(
+    makeEntity(1),
+    makeEntity(2),
+    makeEntity(3)
+  )
+
+  override def beforeAll(): Unit = {
+    val people = quote { query[Contact] }
+    ctx.run(people.delete)
+    ctx.run(liftQuery(contacts).foreach(c => people.insertValue(c)))
+    ctx.run(query[DateEncodingTestEntity].delete)
+    ctx.run(liftQuery(dates).foreach(c => query[DateEncodingTestEntity].insertValue(c)))
+  }
+
+  "Should do correct query from map with" - {
+    "simple datatypes" in {
+      ctx.run(query[Contact].filterByKeys(Map("firstName" -> "Joe", "addressFk" -> 1))) mustEqual
+        List(Contact("Joe","Bloggs",123,1,"1"), Contact("Joe","Noggs",123,1,"1")) //
+    }
+    "string datatypes" in {
+      ctx.run(query[Contact].filterByKeys(Map("firstName" -> "Joe", "addressFk" -> "1"))) mustEqual
+        List(Contact("Joe","Bloggs",123,1,"1"), Contact("Joe","Noggs",123,1,"1"))
+    }
+    "date datatypes" in {
+      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1, "v2" -> makeEntity(1).v2))) mustEqual List()
+    }
+    "date-string datatypes" in {
+      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1.toString, "v2" -> makeEntity(1).v2.toString))) mustEqual List()
+    }
+
+  }
+
+  // "Should fail when cannot convert type from string" - {
+  //   case class Info(value: String)
+  //   implicit val encodeStrWrap: MappedEncoding[Info, String] = MappedEncoding[Info, String](_.value)
+  //   implicit val decodeStrWrap: MappedEncoding[String, Info] = MappedEncoding[String, Info](Info.apply)
+
+  //   case class ContactComplex(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: Info)
+  //   val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
+
+  //   val map = Map[String, Any]("extraInfo" -> "1")
+  //   ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map)) mustEqual List()
+  // }
+
+  // "Should succeed with AnyValue" - {
+  //   import FlicerMapTypesSpec.`Should succeed with AnyValue`._
+  //   val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
+
+  //   val map = Map[String, Any]("extraInfo" -> "1")
+  //   ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map)) mustEqual List()
+  // }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
@@ -47,7 +47,7 @@ class FlicerMapTypesSpec extends Spec with Inside {
   "Should do correct query from map with" - {
     "simple datatypes" in {
       ctx.run(query[Contact].filterByKeys(Map("firstName" -> "Joe", "addressFk" -> 1))) mustEqual
-        List(Contact("Joe","Bloggs",123,1,"1"), Contact("Joe","Noggs",123,1,"1")) //
+        List(Contact("Joe","Bloggs",123,1,"1"), Contact("Joe","Noggs",123,1,"1"))
     }
     "string datatypes" in {
       ctx.run(query[Contact].filterByKeys(Map("firstName" -> "Joe", "addressFk" -> "1"))) mustEqual
@@ -62,23 +62,26 @@ class FlicerMapTypesSpec extends Spec with Inside {
 
   }
 
-  // "Should fail when cannot convert type from string" - {
-  //   case class Info(value: String)
-  //   implicit val encodeStrWrap: MappedEncoding[Info, String] = MappedEncoding[Info, String](_.value)
-  //   implicit val decodeStrWrap: MappedEncoding[String, Info] = MappedEncoding[String, Info](Info.apply)
+  "Should fail when cannot convert type from string" - {
+    case class Info(value: String)
+    implicit val encodeStrWrap: MappedEncoding[Info, String] = MappedEncoding[Info, String](_.value)
+    implicit val decodeStrWrap: MappedEncoding[String, Info] = MappedEncoding[String, Info](Info.apply)
 
-  //   case class ContactComplex(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: Info)
-  //   val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
+    case class ContactComplex(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: Info)
+    val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
 
-  //   val map = Map[String, Any]("extraInfo" -> "1")
-  //   ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map)) mustEqual List()
-  // }
+    val map = Map[String, Any]("extraInfo" -> "1")
+    assertThrows[IllegalStateException] {
+      ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map))
+    }
+  }
 
-  // "Should succeed with AnyValue" - {
-  //   import FlicerMapTypesSpec.`Should succeed with AnyValue`._
-  //   val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
+  "Should succeed with AnyValue" in {
+    import FlicerMapTypesSpec.`Should succeed with AnyValue`._
+    val converted = contacts.map(c => ContactComplex(c.firstName, c.lastName, c.age, c.addressFk, Info(c.extraInfo)))
 
-  //   val map = Map[String, Any]("extraInfo" -> "1")
-  //   ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map)) mustEqual List()
-  // }
+    val map = Map[String, Any]("extraInfo" -> Info("1"))
+    ctx.run(querySchema[ContactComplex]("Contact").filterByKeys(map)) mustEqual
+      List(ContactComplex("Joe","Bloggs",123,1,Info("1")), ContactComplex("Joe","Noggs",123,1,Info("1")))
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/FlicerMapTypesSpec.scala
@@ -54,10 +54,10 @@ class FlicerMapTypesSpec extends Spec with Inside {
         List(Contact("Joe","Bloggs",123,1,"1"), Contact("Joe","Noggs",123,1,"1"))
     }
     "date datatypes" in {
-      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1, "v2" -> makeEntity(1).v2))) mustEqual List()
+      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1, "v2" -> makeEntity(1).v2))) mustEqual List(makeEntity(1))
     }
     "date-string datatypes" in {
-      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1.toString, "v2" -> makeEntity(1).v2.toString))) mustEqual List()
+      ctx.run(query[DateEncodingTestEntity].filterByKeys(Map("v1" -> makeEntity(1).v1.toString, "v2" -> makeEntity(1).v2.toString))) mustEqual List(makeEntity(1))
     }
 
   }

--- a/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample_LiftByKeys.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/examples/MiniExample_LiftByKeys.scala
@@ -19,7 +19,7 @@ object MiniExample_LiftByKeys {
   def regularMapProc() = {
     inline def q = quote {
       query[Person].filter(p =>
-        MapFlicer[Person, PrepareRow, Session](p, values, null, (a, b) => (a == b) || (b == (null) ) )
+        MapFlicer[Person, PrepareRow, Session](p, values)
       )
     }
     val r = run(q)
@@ -51,8 +51,8 @@ object MiniExample_LiftByKeys {
    ============= The following expasion happens ===========
    SELECT p.firstName, p.lastName, p.age FROM Person p
    WHERE
-     ( p.firstName = [ values.getOrElse("firstName",null) ] OR [ values.getOrElse("firstName",null) ] == null ) AND
-     ( p.lastName = [ values.getOrElse("lastName",null) ] OR [ values.getOrElse("lastName",null) ] == null ) AND
+     ( p.firstName = [ values.getOrElse("firstName",null) ] OR [ values.getOrElse("firstName",null) == null ] ) AND
+     ( p.lastName = [ values.getOrElse("lastName",null) ] OR [ values.getOrElse("lastName",null) == null ] ) AND
      ( p.age = [ values.getOrElse("age",null) ] OR [ values.getOrElse("age",null) == null ] ) AND true
   */
 

--- a/quill-sql/src/main/scala/io/getquill/StaticSplice.scala
+++ b/quill-sql/src/main/scala/io/getquill/StaticSplice.scala
@@ -48,9 +48,7 @@ object StringCodec:
       } yield (module)
   object FromString:
     def summonExpr[T: Type](using Quotes) =
-      val output = Expr.summon[io.getquill.FromString[T]].toEitherOr(s"a FromString[${Format.TypeOf[T]}] cannot be summoned")
-      println(s"============== SUMMON RESULT ${Format.TypeOf[T]}: ${output}")
-      output
+      Expr.summon[io.getquill.FromString[T]].toEitherOr(s"a FromString[${Format.TypeOf[T]}] cannot be summoned")
 end StringCodec
 
 // Special case for splicing a string directly i.e. need to add 'single-quotes'

--- a/quill-sql/src/main/scala/io/getquill/StaticSplice.scala
+++ b/quill-sql/src/main/scala/io/getquill/StaticSplice.scala
@@ -9,80 +9,102 @@ import scala.util.Failure
 import scala.util.Success
 import io.getquill.util.CommonExtensions.Either._
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Trait that allows usage of 'static' block. Can declared one of these and use similar to encoders
  * but it needs to be compiled in a previous compilation unit and a global static.
  * TODO More explanation
  */
+trait ToSql[T]:
+  def toSql(value: T): String
+
 trait ToString[T]:
   def toString(value: T): String
 
 trait FromString[T]:
   def fromString(value: String): T
 
-trait StringCodec[T] extends ToString[T] with FromString[T]
+// Most to-sql splices are just the string-value e.g. for numbers. For strings, dates,
+// etc... need to surround with quotes
+// and various other complex things.
+trait StringCodec[T] extends ToString[T] with FromString[T] with ToSql[T]:
+  def toSql(value: T): String = toString(value)
 
 import io.getquill.metaprog.Extractors._
 
 object StringCodec:
-  object ToString:
-    def summon[T: Type](using Quotes): Either[String, ToString[T]] =
+  object ToSql:
+    def summon[T: Type](using Quotes): Either[String, ToSql[T]] =
       import quotes.reflect.{Try => TTry, _}
       for {
-        summonValue <- Expr.summon[io.getquill.ToString[T]].toEitherOr(s"a ToString[${Format.TypeOf[T]}] cannot be summoned")
-        // Summoning ToString[T] will given (SpliceString: ToString[String])
-        // (a.k.a. Typed(Ident(SpliceString), TypeTree(ToString[String])) usually with an outer inline surrounding it all)
+        summonValue <- Expr.summon[io.getquill.ToSql[T]].toEitherOr(s"a ToString[${Format.TypeOf[T]}] cannot be summoned")
+        // Summoning ToSql[T] will given (SpliceString: ToSql[String])
+        // (a.k.a. Typed(Ident(SpliceString), TypeTree(ToSql[String])) usually with an outer inline surrounding it all)
         // so then we need to use Untype to just get SpliceString which is a module that we can load
         staticSpliceType = Untype(summonValue.asTerm.underlyingArgument).tpe.widen
         untypedModule <- Load.Module.fromTypeRepr(staticSpliceType).toEither.mapLeft(_.getMessage)
-        module <- Try(untypedModule.asInstanceOf[io.getquill.ToString[T]]).toEither.mapLeft(_.getMessage)
+        module <- Try(untypedModule.asInstanceOf[io.getquill.ToSql[T]]).toEither.mapLeft(_.getMessage)
       } yield (module)
   object FromString:
     def summonExpr[T: Type](using Quotes) =
-      Expr.summon[io.getquill.FromString[T]].toEitherOr(s"a FromString[${Format.TypeOf[T]}] cannot be summoned")
+      val output = Expr.summon[io.getquill.FromString[T]].toEitherOr(s"a FromString[${Format.TypeOf[T]}] cannot be summoned")
+      println(s"============== SUMMON RESULT ${Format.TypeOf[T]}: ${output}")
+      output
 end StringCodec
 
 // Special case for splicing a string directly i.e. need to add 'single-quotes'
-object SpliceString extends ToString[String]:
-  def toString(value: String) = s"'${value}'"
-inline given ToString[String] = SpliceString
+object SpliceString extends StringCodec[String]:
+  override def toSql(value: String): String = s"'${value}'"
+  def toString(value: String) = value
+  def fromString(value: String) = value
+implicit inline def stringCodec: StringCodec[String] = SpliceString
 
 object SpliceInt extends StringCodec[Int]:
   def toString(value: Int) = s"${value}"
   def fromString(value: String) = value.toInt
-inline given StringCodec[Int] = SpliceInt
+implicit inline def intCodec: StringCodec[Int] = SpliceInt
 
 object SpliceShort extends StringCodec[Short]:
   def toString(value: Short) = s"${value}"
   def fromString(value: String) = value.toShort
-inline given StringCodec[Short] = SpliceShort
+implicit inline def shortCodec: StringCodec[Short] = SpliceShort
 
 object SpliceLong extends StringCodec[Long]:
   def toString(value: Long) = s"${value}"
   def fromString(value: String) = value.toLong
-inline given ToString[Long] = SpliceLong
+implicit inline def longCodec: ToString[Long] = SpliceLong
 
 object SpliceFloat extends StringCodec[Float]:
   def toString(value: Float) = s"${value}"
   def fromString(value: String) = value.toFloat
-inline given StringCodec[Float] = SpliceFloat
+implicit inline def floatCodec: StringCodec[Float] = SpliceFloat
 
 object SpliceDouble extends StringCodec[Double]:
   def toString(value: Double) = s"${value}"
   def fromString(value: String) = value.toDouble
-inline given StringCodec[Double] = SpliceDouble
+implicit inline def doubleCodec: StringCodec[Double] = SpliceDouble
+
+private[getquill] object DateFormats:
+  val parseFormat = DateTimeFormatter.ofPattern("[yyyyMMdd][yyyy-MM-dd]")
+  val printFormat = DateTimeFormatter.ofPattern("yyyyMMdd")
 
 object SpliceDate extends StringCodec[java.sql.Date]:
-  private val dateFormat = DateTimeFormatter.ofPattern("yyyyMMdd")
-  def toString(value: java.sql.Date) = value.toLocalDate.format(dateFormat)
+  override def toSql(value: java.sql.Date): String = s"'${toString(value)}'"
+  def toString(value: java.sql.Date) = value.toLocalDate.format(DateFormats.printFormat)
   def fromString(value: String) =
-    val local = LocalDate.parse(value, dateFormat)
+    val local = LocalDate.parse(value, DateFormats.parseFormat)
     java.sql.Date.valueOf(local)
-inline given StringCodec[java.sql.Date] = SpliceDate
+implicit inline def dateCodec: StringCodec[java.sql.Date] = SpliceDate
 
 object SpliceLocalDate extends StringCodec[java.time.LocalDate]:
-  private val dateFormat = DateTimeFormatter.ofPattern("yyyyMMdd")
-  def toString(value: java.time.LocalDate) = value.format(dateFormat)
-  def fromString(value: String) = LocalDate.parse(value, dateFormat)
-inline given StringCodec[java.time.LocalDate] = SpliceLocalDate
+  override def toSql(value: java.time.LocalDate): String = s"'${toString(value)}'"
+  def toString(value: java.time.LocalDate) = value.format(DateFormats.printFormat)
+  def fromString(value: String) = LocalDate.parse(value, DateFormats.parseFormat)
+implicit inline def localDateCodec: StringCodec[java.time.LocalDate] = SpliceLocalDate
+
+object SpliceLocalDateTime extends StringCodec[java.time.LocalDateTime]:
+  override def toSql(value: java.time.LocalDateTime): String = s"'${toString(value)}'"
+  def toString(value: java.time.LocalDateTime) = value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+  def fromString(value: String) = LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+implicit inline def localDateTimeCodec: StringCodec[java.time.LocalDateTime] = SpliceLocalDateTime

--- a/quill-sql/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/Context.scala
@@ -79,7 +79,7 @@ trait Context[+Dialect <: Idiom, +Naming <: NamingStrategy]
      * When using this with FilterColumns make sure it comes FIRST. Otherwise the columns are you filtering
      * may have been nullified in the SQL before the filteration has actually happened.
      */
-    inline def filterByKeys(inline map: Map[String, String]) =
+    inline def filterByKeys(inline map: Map[String, Any]) =
       q.filter(p => MapFlicer[T, PrepareRow, Session](p, map, null, (a, b) => (a == b) || (b == (null))))
 
     inline def filterColumns(inline columns: List[String]) =

--- a/quill-sql/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/Context.scala
@@ -80,7 +80,7 @@ trait Context[+Dialect <: Idiom, +Naming <: NamingStrategy]
      * may have been nullified in the SQL before the filteration has actually happened.
      */
     inline def filterByKeys(inline map: Map[String, Any]) =
-      q.filter(p => MapFlicer[T, PrepareRow, Session](p, map, null, (a, b) => (a == b) || (b == (null))))
+      q.filter(p => MapFlicer[T, PrepareRow, Session](p, map))
 
     inline def filterColumns(inline columns: List[String]) =
       q.map(p => ColumnsFlicer[T, PrepareRow, Session](p, columns))

--- a/quill-sql/src/main/scala/io/getquill/context/LiftMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/LiftMacro.scala
@@ -189,22 +189,25 @@ object LiftMacro {
     '{ EagerPlanter($valueEntity, $encoder, ${ Expr(uuid) }) } // [T, PrepareRow] // adding these causes assertion failed: unresolved symbols: value Context_this
   }
 
-  def valueOrString[T: Type, PrepareRow: Type, Session: Type](valueEntity: Expr[Any], uuid: String = newUuid, logLine: String = "")(using Quotes) =
+  def valueOrString[T: Type, PrepareRow: Type, Session: Type](valueEntity: Expr[Any], uuid: String = newUuid)(using Quotes) =
     import quotes.reflect._
     // i.e. the actual thing being passed to the encoder e.g. for lift(foo.bar) this will be "foo.bar"
     val fieldName = Format.Expr(valueEntity)
     // The thing being encoded converted to a string, unless it is null then null is returned
     val valueEntityToString = '{ StringOrNull($valueEntity) }
     val nullableEncoder = summonEncoderOrFail[Option[T], PrepareRow, Session](valueEntity)
-    val stringEncoder = summonEncoderOrFail[String, PrepareRow, Session](valueEntityToString)
     val expectedClassTag =
       Expr.summon[ClassTag[T]] match
         case Some(value) => value
         case None        => report.throwError(s"Cannot create a classTag for the type ${Format.TypeOf[T]} for the value ${fieldName}. Cannot create a string-fallback encoder.")
+    val converterExpr: Expr[Either[String, FromString[T]]] =
+      StringCodec.FromString.summonExpr[T] match
+        case Right(value) => '{ Right($value) }
+        case Left(msg)    => '{ Left(${ Expr(msg) }) }
     '{
       EagerPlanter[Any, PrepareRow, Session](
         $valueEntity,
-        GenericEncoderWithStringFallback($nullableEncoder, ${ Expr(logLine) })($expectedClassTag),
+        GenericEncoderWithStringFallback($nullableEncoder, $converterExpr)($expectedClassTag),
         ${ Expr(uuid) }
       ).unquote
     }

--- a/quill-sql/src/main/scala/io/getquill/context/ReflectiveChainLookup.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ReflectiveChainLookup.scala
@@ -1,7 +1,7 @@
 package io.getquill.context
 
 import scala.quoted._
-import io.getquill.StaticSplice
+import io.getquill.ToString
 import io.getquill.util.Load
 import io.getquill.metaprog.Extractors
 import scala.util.Success

--- a/quill-sql/src/main/scala/io/getquill/context/StaticSpliceMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/StaticSpliceMacro.scala
@@ -1,7 +1,7 @@
 package io.getquill.context
 
 import scala.quoted._
-import io.getquill.StaticSplice
+import io.getquill.ToString
 import io.getquill.util.Load
 import io.getquill.metaprog.Extractors
 import scala.util.Success
@@ -14,7 +14,7 @@ import io.getquill.Quoted
 import io.getquill.quat.QuatMaking
 import io.getquill.parser.Lifter
 import scala.util.Try
-import io.getquill.StaticSplice
+import io.getquill.StringCodec
 import io.getquill.util.CommonExtensions.Either._
 import io.getquill.util.CommonExtensions.Throwable._
 import io.getquill.util.CommonExtensions.For._
@@ -133,8 +133,8 @@ object StaticSpliceMacro {
     val spliceEither =
       for {
         castSplice <- Try(splicedValue.current.asInstanceOf[T]).toEither.mapLeft(e => errorMsg(e.getMessage))
-        splicer <- StaticSplice.summon[T].mapLeft(str => errorMsg(str))
-        splice <- Try(splicer(castSplice)).toEither.mapLeft(e => errorMsg(e.getMessage))
+        splicer <- StringCodec.ToString.summon[T].mapLeft(str => errorMsg(str))
+        splice <- Try(splicer.toString(castSplice)).toEither.mapLeft(e => errorMsg(e.getMessage))
       } yield splice
 
     val spliceStr =

--- a/quill-sql/src/main/scala/io/getquill/context/StaticSpliceMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/StaticSpliceMacro.scala
@@ -133,8 +133,8 @@ object StaticSpliceMacro {
     val spliceEither =
       for {
         castSplice <- Try(splicedValue.current.asInstanceOf[T]).toEither.mapLeft(e => errorMsg(e.getMessage))
-        splicer <- StringCodec.ToString.summon[T].mapLeft(str => errorMsg(str))
-        splice <- Try(splicer.toString(castSplice)).toEither.mapLeft(e => errorMsg(e.getMessage))
+        splicer <- StringCodec.ToSql.summon[T].mapLeft(str => errorMsg(str))
+        splice <- Try(splicer.toSql(castSplice)).toEither.mapLeft(e => errorMsg(e.getMessage))
       } yield splice
 
     val spliceStr =

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
@@ -43,6 +43,6 @@ case class GenericEncoderWithStringFallback[T, PrepareRow, Session](
           nullableEncoder(i, Option(t.asInstanceOf[T]).map(v => converter.fromString(v.toString)), row, session)
         case Left(_) =>
           throw new IllegalStateException(
-            s"[WARN] The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}` and could not summon a from-string converter for the type given by: ${classTagExpected}"
+            s"The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}` and could not summon a from-string converter for the type."
           )
 }

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
@@ -3,40 +3,46 @@ package io.getquill.generic
 import io.getquill.metaprog.etc.StringOrNull
 import scala.reflect.ClassTag
 import scala.reflect.classTag
+import io.getquill.StringCodec
+import io.getquill.FromString
 
 // Note: Not using abstract Index parameter in ProtoQuill since it would bleed into most planters
 trait GenericEncoder[T, PrepareRow, Session] extends ((Int, T, PrepareRow, Session) => PrepareRow) {
   def apply(i: Int, t: T, row: PrepareRow, session: Session): PrepareRow
 }
 
-object GenericEncoderWithStringFallback {
-  // TODO create possible converters based on class tags
-  // could even leverage implementations from FromString things but might not be worth it
-  // use the converters as a fallback strategy
-}
-
 case class GenericEncoderWithStringFallback[T, PrepareRow, Session](
     nullableEncoder: GenericEncoder[Option[T], PrepareRow, Session],
-    badExpressionLog: String = ""
+    stringConverter: Either[String, FromString[T]]
 )(classTagExpected: ClassTag[T]) extends GenericEncoder[Any, PrepareRow, Session] {
-  def apply(i: Int, t: Any, row: PrepareRow, session: Session): PrepareRow =
-    val classTagActual =
-      // if the value is just null, use the original encoder, since value conversion shouldn't mater
-      if (t == null) classTagExpected
-      else if (t.isInstanceOf[Int]) classTag[Int]
-      else if (t.isInstanceOf[Long]) classTag[Long]
-      else if (t.isInstanceOf[Short]) classTag[Short]
-      else if (t.isInstanceOf[Float]) classTag[Float]
-      else if (t.isInstanceOf[Double]) classTag[Double]
-      else if (t.isInstanceOf[Boolean]) classTag[Boolean]
-      else if (t.isInstanceOf[Byte]) classTag[Byte]
-      else ClassTag(t.getClass())
 
+  private def classTagFromInstance(t: Any) =
+    // if the value is just null, use the original encoder, since value conversion shouldn't mater
+    if (t == null) classTagExpected
+    else if (t.isInstanceOf[Int]) classTag[Int]
+    else if (t.isInstanceOf[Long]) classTag[Long]
+    else if (t.isInstanceOf[Short]) classTag[Short]
+    else if (t.isInstanceOf[Float]) classTag[Float]
+    else if (t.isInstanceOf[Double]) classTag[Double]
+    else if (t.isInstanceOf[Boolean]) classTag[Boolean]
+    else if (t.isInstanceOf[Byte]) classTag[Byte]
+    else ClassTag(t.getClass())
+
+  def apply(i: Int, t: Any, row: PrepareRow, session: Session): PrepareRow =
+    val classTagActual = classTagFromInstance(t)
     if (t == null || classTagActual <:< classTagExpected)
-      println(s"=============== ENCODING ${classTagActual}: $t as: ${Option(t.asInstanceOf[T])}")
+      // println(s"=============== ENCODING ${classTagActual}: $t as: ${Option(t.asInstanceOf[T])}")
       nullableEncoder(i, Option(t.asInstanceOf[T]), row, session)
     else
-      // using pprint here because want quotes if it is a string value etc...
-      println(s"[WARN] The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}`.${badExpressionLog}")
-      nullableEncoder(i, Option(t.asInstanceOf[T]), row, session)
+      stringConverter match
+        case Right(converter) =>
+          // using pprint here because want quotes if it is a string value etc...
+          println(
+            s"[WARN] The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}`. Will attempt to convert to string and use the provided from-string converter: $converter."
+          )
+          nullableEncoder(i, Option(t.asInstanceOf[T]).map(v => converter.fromString(v.toString)), row, session)
+        case Left(_) =>
+          throw new IllegalStateException(
+            s"[WARN] The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}` and could not summon a from-string converter for the type given by: ${classTagExpected}"
+          )
 }

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericEncoder.scala
@@ -1,6 +1,38 @@
 package io.getquill.generic
 
+import io.getquill.metaprog.etc.StringOrNull
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+
 // Note: Not using abstract Index parameter in ProtoQuill since it would bleed into most planters
 trait GenericEncoder[T, PrepareRow, Session] extends ((Int, T, PrepareRow, Session) => PrepareRow) {
   def apply(i: Int, t: T, row: PrepareRow, session: Session): PrepareRow
+}
+
+case class GenericEncoderWithStringFallback[T, PrepareRow, Session](
+    original: GenericEncoder[T, PrepareRow, Session],
+    fallback: GenericEncoder[String, PrepareRow, Session],
+    badExpressionLog: String = ""
+)(classTagExpected: ClassTag[T]) extends GenericEncoder[Any, PrepareRow, Session] {
+  def apply(i: Int, t: Any, row: PrepareRow, session: Session): PrepareRow =
+    val classTagActual =
+      // if the value is just null, use the original encoder, since value conversion shouldn't mater
+      if (t == null) classTagExpected
+      else if (t.isInstanceOf[Int]) classTag[Int]
+      else if (t.isInstanceOf[Long]) classTag[Long]
+      else if (t.isInstanceOf[Short]) classTag[Short]
+      else if (t.isInstanceOf[Float]) classTag[Float]
+      else if (t.isInstanceOf[Double]) classTag[Double]
+      else if (t.isInstanceOf[Boolean]) classTag[Boolean]
+      else if (t.isInstanceOf[Byte]) classTag[Byte]
+      else ClassTag(t.getClass())
+
+    if (t == null)
+      original(i, t.asInstanceOf[T], row, session)
+    else if (classTagActual <:< classTagExpected)
+      original(i, t.asInstanceOf[T], row, session)
+    else
+      // using pprint here because want quotes if it is a string value etc...
+      println(s"[WARN] The field value: ${pprint(t).plainText} had the type `${classTagActual}` but was expecting the type `${classTagExpected}`.${badExpressionLog}")
+      fallback(i, StringOrNull(t), row, session)
 }

--- a/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
@@ -477,6 +477,7 @@ object Extractors {
     import quotes.reflect._
     tpe <:< TypeRepr.of[String] ||
     tpe <:< TypeRepr.of[Int] ||
+    tpe <:< TypeRepr.of[Short] ||
     tpe <:< TypeRepr.of[Long] ||
     tpe <:< TypeRepr.of[Float] ||
     tpe <:< TypeRepr.of[Double] ||
@@ -487,6 +488,7 @@ object Extractors {
     import quotes.reflect._
     tpe <:< TypeRepr.of[Int] ||
     tpe <:< TypeRepr.of[Long] ||
+    tpe <:< TypeRepr.of[Short] ||
     tpe <:< TypeRepr.of[Float] ||
     tpe <:< TypeRepr.of[Double] ||
     tpe <:< TypeRepr.of[scala.math.BigDecimal] ||

--- a/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
@@ -18,11 +18,11 @@ import io.getquill.util.Format
 
 // I.e. Map-Folding-Splicer since it recursively spliced clauses into a map
 object MapFlicer {
-  inline def apply[T, PrepareRow, Session](inline entity: T, inline map: Map[String, Any], inline default: Any, inline eachField: (Any, Any) => Boolean): Boolean =
-    ${ applyImpl[T, PrepareRow, Session]('entity, 'map, 'default, 'eachField) }
-  private def applyImpl[T: Type, PrepareRow: Type, Session: Type](entity: Expr[T], map: Expr[Map[String, Any]], default: Expr[Any], eachField: Expr[(Any, Any) => Boolean])(using Quotes): Expr[Boolean] = {
+  inline def apply[T, PrepareRow, Session](inline entity: T, inline map: Map[String, Any]): Boolean =
+    ${ applyImpl[T, PrepareRow, Session]('entity, 'map) }
+  private def applyImpl[T: Type, PrepareRow: Type, Session: Type](entity: Expr[T], map: Expr[Map[String, Any]])(using Quotes): Expr[Boolean] = {
     val mp = new MapFlicerMacro
-    val ret = mp.base[T, PrepareRow, Session](entity, map, default, eachField)
+    val ret = mp.base[T, PrepareRow, Session](entity, map)
     ret
   }
 }
@@ -40,7 +40,7 @@ class MapFlicerMacro {
     import quotes.reflect._
     TypeRepr.of(using tpe) <:< TypeRepr.of[Product]
 
-  private def buildClause[T: Type, PrepareRow: Type, Session: Type](core: Expr[T])(eachField: Expr[(Any, Any) => Boolean], map: Expr[Map[String, Any]], default: Expr[Any])(using Quotes): Expr[Boolean] =
+  private def buildClause[T: Type, PrepareRow: Type, Session: Type](core: Expr[T])(map: Expr[Map[String, Any]])(using Quotes): Expr[Boolean] =
     import quotes.reflect._
     ElaborateStructure.decomposedProductValueDetails[T](ElaborationSide.Encoding, UdtBehavior.Leaf) match
       case (terms, Leaf) => report.throwError("Not supported yet", core)
@@ -56,17 +56,17 @@ class MapFlicerMacro {
                 childTTerm.asTerm.tpe
 
             // Note usually `default` is null and cannot do asExprOf[T] on it otherwise will get a `of type: scala.Any... did not conform to type: java.lang.String/Int/etc...` exception
-            def mapSplice = '{ $map.getOrElse(${ Expr[String](fieldString) }, ${ default }) }
+            def mapSplice = '{ $map.getOrElse(${ Expr[String](fieldString) }, null) }
             def fieldInject[T](field: Expr[T])(using Type[T]) =
               val printType = Expr(Format.TypeOf[T].toString)
               val printTerm = Expr(Format.Expr(childTTerm).toString)
               '{
-                $eachField(
-                  $field,
-                  ${
-                    LiftMacro.valueOrString[T, PrepareRow, Session](mapSplice)
-                  }
-                )
+                // Originally we spliced `LiftMacro.valueOrString[T,...](mapSplice) == null` as the 2nd part of the || clause but that would generate
+                // query[Person](p => ... p.bornAt == ? || ? IS NULL ) --where ? is lift(map("bornAt"))
+                // This should be totally fine but if postgres can't handle `? IS NULL` if `?` is a timestamp, even if the type is explicitly state in the encoder
+                // (Reason for this insane behavior is described here: https://github.com/pgjdbc/pgjdbc/issues/276).
+                // So instead we just splice a check if the value is null into the `lift` call and the problem is entirely avoided.
+                $field == ${ LiftMacro.valueOrString[T, PrepareRow, Session](mapSplice) } || ${ LiftMacro[Boolean, PrepareRow, Session]('{ $mapSplice == null }) }
               }
 
             // If the field is optional, the inner type has already been unpacked by `decomposedProductValueDetails` so we just use it
@@ -86,8 +86,8 @@ class MapFlicerMacro {
 
   def base[T, PrepareRow, Session](using
       Quotes
-  )(expr: Expr[T], map: Expr[Map[String, Any]], default: Expr[Any], eachField: Expr[(Any, Any) => Boolean])(using tpe: Type[T], pr: Type[PrepareRow], sess: Type[Session]): Expr[Boolean] = {
+  )(expr: Expr[T], map: Expr[Map[String, Any]])(using tpe: Type[T], pr: Type[PrepareRow], sess: Type[Session]): Expr[Boolean] = {
     import quotes.reflect._
-    buildClause[T, PrepareRow, Session](expr)(eachField, map, default)
+    buildClause[T, PrepareRow, Session](expr)(map)
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
@@ -47,7 +47,6 @@ class MapFlicerMacro {
       case (terms, Branch) =>
         val boolTerms =
           terms.map { (fieldString, isOptional, getter, tpe) =>
-            val logLine = s" (For the map-lifted expression `${fieldString}`. Need to auto-cast to string before lifting which may introduce unexpected errors.)"
             val childTTerm = getter(core)
             val actualChildType =
               if (isOptional)
@@ -65,7 +64,7 @@ class MapFlicerMacro {
                 $eachField(
                   $field,
                   ${
-                    LiftMacro.valueOrString[T, PrepareRow, Session](mapSplice, logLine = logLine)
+                    LiftMacro.valueOrString[T, PrepareRow, Session](mapSplice)
                   }
                 )
               }

--- a/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/etc/MapFlicer.scala
@@ -14,16 +14,21 @@ import io.getquill.generic.ConstructType
 import io.getquill.generic.DeconstructElaboratedEntityLevels
 import io.getquill.generic.ElaborateStructure.{TermType, Leaf, Branch}
 import io.getquill.generic.ElaborateStructure.UdtBehavior
+import io.getquill.util.Format
 
 // I.e. Map-Folding-Splicer since it recursively spliced clauses into a map
 object MapFlicer {
-  inline def apply[T, PrepareRow, Session](inline entity: T, inline map: Map[String, String], inline default: String, inline eachField: (String, String) => Boolean): Boolean =
+  inline def apply[T, PrepareRow, Session](inline entity: T, inline map: Map[String, Any], inline default: Any, inline eachField: (Any, Any) => Boolean): Boolean =
     ${ applyImpl[T, PrepareRow, Session]('entity, 'map, 'default, 'eachField) }
-  private def applyImpl[T: Type, PrepareRow: Type, Session: Type](entity: Expr[T], map: Expr[Map[String, String]], default: Expr[String], eachField: Expr[(String, String) => Boolean])(using Quotes): Expr[Boolean] = {
+  private def applyImpl[T: Type, PrepareRow: Type, Session: Type](entity: Expr[T], map: Expr[Map[String, Any]], default: Expr[Any], eachField: Expr[(Any, Any) => Boolean])(using Quotes): Expr[Boolean] = {
     val mp = new MapFlicerMacro
     val ret = mp.base[T, PrepareRow, Session](entity, map, default, eachField)
     ret
   }
+}
+
+object StringOrNull {
+  def apply(v: Any): String = if (v == null) null else v.toString
 }
 
 /**
@@ -35,32 +40,54 @@ class MapFlicerMacro {
     import quotes.reflect._
     TypeRepr.of(using tpe) <:< TypeRepr.of[Product]
 
-  private def buildClause[T: Type, PrepareRow: Type, Session: Type](core: Expr[T])(eachField: Expr[(String, String) => Boolean], map: Expr[Map[String, String]], default: Expr[String])(using Quotes): Expr[Boolean] =
+  private def buildClause[T: Type, PrepareRow: Type, Session: Type](core: Expr[T])(eachField: Expr[(Any, Any) => Boolean], map: Expr[Map[String, Any]], default: Expr[Any])(using Quotes): Expr[Boolean] =
     import quotes.reflect._
     ElaborateStructure.decomposedProductValueDetails[T](ElaborationSide.Encoding, UdtBehavior.Leaf) match
       case (terms, Leaf) => report.throwError("Not supported yet", core)
       case (terms, Branch) =>
         val boolTerms =
           terms.map { (fieldString, isOptional, getter, tpe) =>
-            val childTTerm = getter(core).asExprOf[Any]
-            val mapSplice = '{ $map.getOrElse(${ Expr[String](fieldString) }, $default) }
+            val logLine = s" (For the map-lifted expression `${fieldString}`. Need to auto-cast to string before lifting which may introduce unexpected errors.)"
+            val childTTerm = getter(core)
+            val actualChildType =
+              if (isOptional)
+                childTTerm.asTerm.tpe.asType match
+                  case '[Option[t]] => TypeRepr.of[t]
+              else
+                childTTerm.asTerm.tpe
 
-            def fieldInject(field: Expr[String]) =
-              '{ $eachField($field, ${ LiftMacro.apply[String, PrepareRow, Session](mapSplice) }) }
+            // Note usually `default` is null and cannot do asExprOf[T] on it otherwise will get a `of type: scala.Any... did not conform to type: java.lang.String/Int/etc...` exception
+            def mapSplice = '{ $map.getOrElse(${ Expr[String](fieldString) }, ${ default }) }
+            def fieldInject[T](field: Expr[T])(using Type[T]) =
+              val printType = Expr(Format.TypeOf[T].toString)
+              val printTerm = Expr(Format.Expr(childTTerm).toString)
+              '{
+                $eachField(
+                  $field,
+                  ${
+                    LiftMacro.valueOrString[T, PrepareRow, Session](mapSplice, logLine = logLine)
+                  }
+                )
+              }
 
             // If the field is optional, the inner type has already been unpacked by `decomposedProductValueDetails` so we just use it
-            if (isOptional)
-              tpe match
-                case '[inner] =>
-                  '{ ${ childTTerm.asExprOf[Option[inner]] }.exists(field => ${ fieldInject('{ field.toString }) }) }
-            else
-              fieldInject('{ $childTTerm.toString })
+            tpe match
+              case '[inner] =>
+                // Assuming: actualChildType <:< TypeRepr.of[inner]
+                if (isOptional)
+                  '{
+                    ${ childTTerm.asExprOf[Option[inner]] }.exists(field =>
+                      ${ fieldInject[inner]('{ field }) }
+                    )
+                  }
+                else
+                  fieldInject[inner](childTTerm.asExprOf[inner])
           }
         boolTerms.reduce((a, b) => '{ $a && $b })
 
   def base[T, PrepareRow, Session](using
       Quotes
-  )(expr: Expr[T], map: Expr[Map[String, String]], default: Expr[String], eachField: Expr[(String, String) => Boolean])(using tpe: Type[T], pr: Type[PrepareRow], sess: Type[Session]): Expr[Boolean] = {
+  )(expr: Expr[T], map: Expr[Map[String, Any]], default: Expr[Any], eachField: Expr[(Any, Any) => Boolean])(using tpe: Type[T], pr: Type[PrepareRow], sess: Type[Session]): Expr[Boolean] = {
     import quotes.reflect._
     buildClause[T, PrepareRow, Session](expr)(eachField, map, default)
   }

--- a/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -48,15 +48,14 @@ object QuatMaking:
 
   private val encodeableCache: mutable.Map[QuotesTypeRepr, Boolean] = mutable.Map()
   def lookupIsEncodeable(tpe: QuotesTypeRepr)(computeEncodeable: () => Boolean) =
-    computeEncodeable()
-  // val lookup = encodeableCache.get(tpe)
-  // lookup match
-  //   case Some(value) =>
-  //     value
-  //   case None =>
-  //     val encodeable = computeEncodeable()
-  //     encodeableCache.put(tpe, encodeable)
-  //     encodeable
+    val lookup = encodeableCache.get(tpe)
+    lookup match
+      case Some(value) =>
+        value
+      case None =>
+        val encodeable = computeEncodeable()
+        encodeableCache.put(tpe, encodeable)
+        encodeable
 
   private val quatCache: mutable.Map[QuotesTypeRepr, Quat] = mutable.Map()
   def lookupCache(tpe: QuotesTypeRepr)(computeQuat: () => Quat) =

--- a/quill-sql/src/test/scala/io/getquill/FlicersSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/FlicersSpec.scala
@@ -35,8 +35,8 @@ class FlicersSpec extends Spec {
       }
       val r = ctx.run(q)
       val (qry, lifts, executionType) = r.triple
-      qry mustEqual "SELECT p.firstName, p.lastName, p.age FROM PersonFlat p WHERE (p.firstName = ? OR ? IS NULL) AND (p.lastName = ? OR ? IS NULL) AND (p.age = ? OR ? IS NULL)"
-      lifts mustEqual List("Joe", "Joe", null, null, "123", "123")
+      qry mustEqual "SELECT p.firstName, p.lastName, p.age FROM PersonFlat p WHERE (p.firstName = ? OR ?) AND (p.lastName = ? OR ?) AND (p.age = ? OR ?)"
+      lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false)
       executionType mustEqual ExecutionType.Static
     }
 
@@ -51,24 +51,24 @@ class FlicersSpec extends Spec {
         val keys = Map[String, Any]("s" -> "Joe", "so" -> "Joe", "i" -> 123, "io" -> 123, "ld" -> now, "ldo" -> now)
         val r = ctx.run(q(keys))
         val (qry, lifts, executionType) = r.triple
-        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ? IS NULL) AND (p.so = ? OR ? IS NULL) AND (p.i = ? OR ? IS NULL) AND (p.io = ? OR ? IS NULL) AND (p.ld = ? OR ? IS NULL) AND (p.ldo = ? OR ? IS NULL)"
-        lifts mustEqual List("Joe", "Joe", "Joe", "Joe", 123, 123, 123, 123, now, now, now, now)
+        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ?) AND (p.so = ? OR ?) AND (p.i = ? OR ?) AND (p.io = ? OR ?) AND (p.ld = ? OR ?) AND (p.ldo = ? OR ?)"
+        lifts mustEqual List(Some("Joe"), false, Some("Joe"), false, Some(123), false, Some(123), false, Some(now), false, Some(now), false)
         executionType mustEqual ExecutionType.Static
       }
       "Splice on an object multiple encoding types - missing Nones" in {
         val keys = Map[String, Any]("s" -> "Joe", "i" -> 123, "ld" -> now)
         val r = ctx.run(q(keys))
         val (qry, lifts, executionType) = r.triple
-        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ? IS NULL) AND (p.so = ? OR ? IS NULL) AND (p.i = ? OR ? IS NULL) AND (p.io = ? OR ? IS NULL) AND (p.ld = ? OR ? IS NULL) AND (p.ldo = ? OR ? IS NULL)"
-        lifts mustEqual List("Joe", "Joe", null, null, 123, 123, null, null, now, now, null, null)
+        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ?) AND (p.so = ? OR ?) AND (p.i = ? OR ?) AND (p.io = ? OR ?) AND (p.ld = ? OR ?) AND (p.ldo = ? OR ?)"
+        lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false, None, true, Some(now), false, None, true)
         executionType mustEqual ExecutionType.Static
       }
       "Splice on an object multiple encoding types - missing All" in {
         val keys = Map[String, Any]("s" -> "Joe", "i" -> 123, "ld" -> now)
         val r = ctx.run(q(keys))
         val (qry, lifts, executionType) = r.triple
-        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ? IS NULL) AND (p.so = ? OR ? IS NULL) AND (p.i = ? OR ? IS NULL) AND (p.io = ? OR ? IS NULL) AND (p.ld = ? OR ? IS NULL) AND (p.ldo = ? OR ? IS NULL)"
-        lifts mustEqual List("Joe", "Joe", null, null, 123, 123, null, null, now, now, null, null)
+        qry mustEqual "SELECT p.s, p.so, p.i, p.io, p.ld, p.ldo FROM ManyTypes p WHERE (p.s = ? OR ?) AND (p.so = ? OR ?) AND (p.i = ? OR ?) AND (p.io = ? OR ?) AND (p.ld = ? OR ?) AND (p.ldo = ? OR ?)"
+        lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false, None, true, Some(now), false, None, true)
         executionType mustEqual ExecutionType.Static
       }
     }
@@ -80,8 +80,8 @@ class FlicersSpec extends Spec {
       }
       val r = ctx.run(q)
       val (qry, lifts, executionType) = r.triple
-      qry mustEqual "SELECT p.firstName, p.lastName, p.age FROM PersonFlatOpt p WHERE (p.firstName = ? OR ? IS NULL) AND (p.lastName = ? OR ? IS NULL) AND (p.age = ? OR ? IS NULL)"
-      lifts mustEqual List("Joe", "Joe", null, null, "123", "123")
+      qry mustEqual "SELECT p.firstName, p.lastName, p.age FROM PersonFlatOpt p WHERE (p.firstName = ? OR ?) AND (p.lastName = ? OR ?) AND (p.age = ? OR ?)"
+      lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false)
       executionType mustEqual ExecutionType.Static
     }
 
@@ -92,8 +92,8 @@ class FlicersSpec extends Spec {
       }
       val r = ctx.run(q)
       val (qry, lifts, executionType) = r.triple
-      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNest p WHERE (p.first = ? OR ? IS NULL) AND (p.last = ? OR ? IS NULL) AND (p.age = ? OR ? IS NULL)"
-      lifts mustEqual List("Joe", "Joe", null, null, "123", "123")
+      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNest p WHERE (p.first = ? OR ?) AND (p.last = ? OR ?) AND (p.age = ? OR ?)"
+      lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false)
       executionType mustEqual ExecutionType.Static
     }
 
@@ -104,8 +104,8 @@ class FlicersSpec extends Spec {
       }
       val r = ctx.run(q)
       val (qry, lifts, executionType) = r.triple
-      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNestOpt p WHERE (p.first = ? OR ? IS NULL) AND (p.last = ? OR ? IS NULL) AND (p.age = ? OR ? IS NULL)"
-      lifts mustEqual List("Joe", "Joe", null, null, "123", "123")
+      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNestOpt p WHERE (p.first = ? OR ?) AND (p.last = ? OR ?) AND (p.age = ? OR ?)"
+      lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false)
       executionType mustEqual ExecutionType.Static
     }
 
@@ -116,8 +116,8 @@ class FlicersSpec extends Spec {
       }
       val r = ctx.run(q) //
       val (qry, lifts, executionType) = r.triple
-      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNestOptField p WHERE (p.first = ? OR ? IS NULL) AND (p.last = ? OR ? IS NULL) AND (p.age = ? OR ? IS NULL)"
-      lifts mustEqual List("Joe", "Joe", null, null, "123", "123")
+      qry mustEqual "SELECT p.first, p.last, p.age FROM PersonNestOptField p WHERE (p.first = ? OR ?) AND (p.last = ? OR ?) AND (p.age = ? OR ?)"
+      lifts mustEqual List(Some("Joe"), false, None, true, Some(123), false)
       executionType mustEqual ExecutionType.Static
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -30,10 +30,11 @@ class QuatSpec extends AnyFreeSpec {
       "quatOf[TestEnum.MyEnum]" mustNot compile
       "quote(query[TestEnum.MyEnumContainer])" mustNot compile
     }
-    "should succeed plain enum if there is encoder" in {
-      given MappedEncoding[TestEnum.MyEnum, String](_.toString)
-      quote(query[TestEnum.MyEnumContainer])
-    }
+    // TODO Why doesn't this work?
+    // "should succeed plain enum if there is encoder" in {
+    //   given MappedEncoding[TestEnum.MyEnum, String](_.toString)
+    //   quote(query[TestEnum.MyEnumContainer])
+    // }
     "should succeed product-type enum" in {
       quatOf[TestEnum.ProductEnum] mustEqual Quat.Product("stuff" -> Quat.Value, "otherStuff" -> Quat.Value)
     }

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -135,6 +135,8 @@ CREATE TABLE Contact(
     extraInfo VARCHAR(255)
 );
 
+--CREATE INDEX firstAndLast  ON Contact (firstname, lastname);
+
 CREATE TABLE Address(
     id int,
     street VARCHAR(255),

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -2,3 +2,9 @@
 
 # From 'All In One' of Quill CONTRIBUTING.md
 docker-compose down && docker-compose build && docker-compose run --rm --service-ports setup
+
+# echo "Adding 50ms latency to protoquill_postgres_1"
+# docker exec protoquill_postgres_1 tc qdisc add dev eth0 root netem delay 50ms
+
+# echo "Adding 50ms latency to protoquill_mysql_1"
+# docker exec protoquill_mysql_1 tc qdisc add dev eth0 root netem delay 50ms


### PR DESCRIPTION
This issue doesn't actually have anything directly to do with quill-caliban but it is a result of the `filterByKeys` method which the quill-caliban module most directly replies upon. Originally an assumption was made that the map being passed into `filterByKeys` can be a `Map[String, String]` for example using `Map("name"->"Joe", "age"->"123")` for `Person(name: String, age: Int)` and use the string-encoder (invoking it as `encode[String]("123")` for `age` replying upon SQL's auto conversion features. Unfortunately, this did not turn out to be possible for many things. For example, for dates the result would effectively be `encode[String](localDate.toString)` e.g. `encode[String]("2022-01-01")` and SQL cannot even parse `"2022-01-01"` do a date object if it tries to compare it to an existing field e.g. `person.bornOn == ? /*lift(encode("2022-01-01"))*/`.

Removing this assumption requires changing the design of `filterByKeys` to take a map that has correct types e.g. `Map("name"->"Joe", "age"->123)`, however this assumption might be too strict. For example what if the map contains the string-encoded version of an integer or date e.g. `Map("name"->"Joe", "age"->"123", bornOn -> "20220101")`. Clearly we want to be a little bit flexible about the types being used in the map. Now, we know what encoder to summon for each `person._ == ? /*lift[encoder]*/` expression because we get them from the entity-type i.e. `Person`. However, if the thing being plugged into this lift is not that type, we want to at least serialize the value in `lift(...)` to a string and then try to encode it. However, because of limitations in some database (e.g. Postgres!) we can't necessarily do comparison across datatypes e.g. `p.age == lift("123")` because of limitations of the DB auto-conversion. Therefore we need to check what the type goes into the lift (we know it is based on the entity field e.g. `Person.age: Int` and try to summon something that convert to that from a string (the FromExprs have been implemented based on that). We decided to extend the concept of StringSplicer to a full String-codec that can convert to/from strings.