### PR TITLE
Json/Jsonb Encoding for Postgres. Bump ZIO

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val `quill-sql` =
         "com.lihaoyi" %% "pprint" % "0.6.6",
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
         "io.getquill" %% "quill-engine" % "4.5.0",
-        "dev.zio" %% "zio" % "2.0.0",
+        "dev.zio" %% "zio" % "2.0.2",
         ("io.getquill" %% "quill-util" % "4.5.0")
           .excludeAll({
             if (isCommunityBuild)
@@ -239,8 +239,8 @@ lazy val `quill-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "2.0.0",
-        "dev.zio" %% "zio-streams" % "2.0.0"
+        "dev.zio" %% "zio" % "2.0.2",
+        "dev.zio" %% "zio-streams" % "2.0.2"
       )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
@@ -251,6 +251,11 @@ lazy val `quill-jdbc-zio` =
     .settings(releaseSettings: _*)
     .settings(jdbcTestingLibraries: _*)
     .settings(
+      libraryDependencies ++= Seq(
+        // Needed for PGObject in JsonExtensions but not necessary if user is not using postgres
+        "org.postgresql" % "postgresql" % "42.3.6" %  "provided",
+        "dev.zio" %% "zio-json" % "0.3.0"
+      ),
        Test / runMain / fork := true,
        Test / fork := true,
        Test / testGrouping := {
@@ -288,8 +293,8 @@ lazy val `quill-cassandra-zio` =
       Test / fork := true,
       libraryDependencies ++= Seq(
         "com.datastax.oss" % "java-driver-core" % "4.13.0",
-        "dev.zio" %% "zio" % "2.0.0",
-        "dev.zio" %% "zio-streams" % "2.0.0"
+        "dev.zio" %% "zio" % "2.0.2",
+        "dev.zio" %% "zio-streams" % "2.0.2"
       )
     )
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")

--- a/quill-caliban/src/test/scala/io/getquill/CalibanSpec.scala
+++ b/quill-caliban/src/test/scala/io/getquill/CalibanSpec.scala
@@ -35,7 +35,7 @@ trait CalibanSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
 
   extension [A](qzio: ZIO[Any, Throwable, A])
     def unsafeRunSync(): A =
-      zio.Unsafe.unsafe {
+      zio.Unsafe.unsafe { implicit unsafe =>
         zio.Runtime.default.unsafe.run(qzio).getOrThrow()
       }
 

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/ZioCassandraSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/ZioCassandraSpec.scala
@@ -8,7 +8,7 @@ import io.getquill.*
 
 object ZioCassandraSpec {
   def runLayerUnsafe[T: Tag](layer: ZLayer[Any, Throwable, T]): T =
-    zio.Unsafe.unsafe {
+    zio.Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(zio.Scope.global.extend(layer.build)).getOrThrow()
     }.get
 }
@@ -32,12 +32,12 @@ trait ZioCassandraSpec extends Spec {
     stream.run(ZSink.collectAll).map(_.toList)
 
   def result[T](stream: ZStream[CassandraZioSession, Throwable, T]): List[T] =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(stream.run(ZSink.collectAll).map(_.toList).provideEnvironment(ZEnvironment(pool))).getOrThrow()
     }
 
   def result[T](qzio: ZIO[CassandraZioSession, Throwable, T]): T =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(qzio.provideEnvironment(ZEnvironment(pool))).getOrThrow()
     }
 

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/other/PlainApp.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/other/PlainApp.scala
@@ -23,7 +23,7 @@ object PlainApp {
         .tap(result => printLine(result.toString))
         .provide(zioSession)
 
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(czio).getOrThrow()
     }
     ()

--- a/quill-jdbc-zio/src/main/scala/io/getquill/JsonValue.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/JsonValue.scala
@@ -1,0 +1,5 @@
+package io.getquill
+
+trait JsonValueBase[T] { def value: T }
+case class JsonValue[T](value: T) extends JsonValueBase[T]
+case class JsonbValue[T](value: T) extends JsonValueBase[T]

--- a/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/ZioJdbcContexts.scala
@@ -7,10 +7,12 @@ import io.getquill.context.qzio.{ ZioJdbcContext, ZioJdbcUnderlyingContext }
 import io.getquill.util.LoadConfig
 
 import javax.sql.DataSource
+import io.getquill.context.json.PostgresJsonExtensions
 
 class PostgresZioJdbcContext[+N <: NamingStrategy](val naming: N)
   extends ZioJdbcContext[PostgresDialect, N]
-  with PostgresJdbcTypes[PostgresDialect, N] {
+  with PostgresJdbcTypes[PostgresDialect, N]
+  with PostgresJsonExtensions {
   val idiom: PostgresDialect = PostgresDialect
 
   val connDelegate: ZioJdbcUnderlyingContext[PostgresDialect, N] = new PostgresZioJdbcContext.Underlying[N](naming)
@@ -18,7 +20,8 @@ class PostgresZioJdbcContext[+N <: NamingStrategy](val naming: N)
 object PostgresZioJdbcContext {
   class Underlying[+N <: NamingStrategy](val naming: N)
     extends ZioJdbcUnderlyingContext[PostgresDialect, N]
-    with PostgresJdbcTypes[PostgresDialect, N] {
+    with PostgresJdbcTypes[PostgresDialect, N]
+    with PostgresJsonExtensions {
     val idiom: PostgresDialect = PostgresDialect
   }
 }

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/json/PostgresJsonExtensions.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/json/PostgresJsonExtensions.scala
@@ -1,0 +1,75 @@
+package io.getquill.context.json
+
+import io.getquill.context.jdbc.{ Decoders, Encoders, JdbcContextTypes }
+import zio.json.{ JsonDecoder, JsonEncoder }
+import zio.json.ast.Json
+
+import java.sql.Types
+import scala.reflect.{ ClassTag, classTag }
+import io.getquill.{ JsonValue, JsonbValue }
+
+trait PostgresJsonExtensions extends Encoders with Decoders {
+  this: JdbcContextTypes[_, _] =>
+
+  implicit def jsonEntityEncoder[T](implicit jsonEncoder: JsonEncoder[T]): Encoder[JsonValue[T]] =
+    entityEncoder[T, JsonValue[T]](_.value)("json", jsonEncoder)
+  implicit def jsonEntityDecoder[T: ClassTag](implicit jsonDecoder: JsonDecoder[T]): Decoder[JsonValue[T]] =
+    entityDecoder[T, JsonValue[T]](JsonValue(_))("json", jsonDecoder)
+  implicit def jsonbEntityEncoder[T](implicit jsonEncoder: JsonEncoder[T]): Encoder[JsonbValue[T]] =
+    entityEncoder[T, JsonbValue[T]](_.value)("jsonb", jsonEncoder)
+  implicit def jsonbEntityDecoder[T: ClassTag](implicit jsonDecoder: JsonDecoder[T]): Decoder[JsonbValue[T]] =
+    entityDecoder[T, JsonbValue[T]](JsonbValue(_))("jsonb", jsonDecoder)
+
+  implicit def jsonAstEncoder: Encoder[JsonValue[Json]] = astEncoder(_.value.toString(), "json")
+  implicit def jsonAstDecoder: Decoder[JsonValue[Json]] = astDecoder(JsonValue(_))
+  implicit def jsonbAstEncoder: Encoder[JsonbValue[Json]] = astEncoder(_.value.toString(), "jsonb")
+  implicit def jsonbAstDecoder: Decoder[JsonbValue[Json]] = astDecoder(JsonbValue(_))
+
+  def astEncoder[Wrapper](valueToString: Wrapper => String, jsonType: String): Encoder[Wrapper] =
+    encoder(Types.VARCHAR, (index, jsonValue, row) => {
+      val obj = new org.postgresql.util.PGobject()
+      obj.setType(jsonType)
+      val jsonString = valueToString(jsonValue)
+      obj.setValue(jsonString)
+      row.setObject(index, obj)
+    })
+
+  def astDecoder[Wrapper](valueFromString: Json => Wrapper): Decoder[Wrapper] =
+    decoder((index, row, session) => {
+      val obj = row.getObject(index, classOf[org.postgresql.util.PGobject])
+      val jsonString = obj.getValue
+      Json.decoder.decodeJson(jsonString) match {
+        case Right(value) => valueFromString(value)
+        case Left(error)  => throw new IllegalArgumentException(s"Error decoding the Json value '${jsonString}' into a zio.json.ast.Json. Message: ${error}")
+      }
+    })
+
+  def entityEncoder[JsValue, Wrapper](
+    unwrap: Wrapper => JsValue
+  )(
+    jsonType:    String,
+    jsonEncoder: JsonEncoder[JsValue]
+  ): Encoder[Wrapper] =
+    encoder(Types.VARCHAR, (index, jsonValue, row) => {
+      val obj = new org.postgresql.util.PGobject()
+      obj.setType(jsonType)
+      val jsonString = jsonEncoder.encodeJson(unwrap(jsonValue), None).toString
+      obj.setValue(jsonString)
+      row.setObject(index, obj)
+    })
+
+  def entityDecoder[JsValue: ClassTag, Wrapper](
+    wrap: JsValue => Wrapper
+  )(
+    jsonType:    String,
+    jsonDecoder: JsonDecoder[JsValue]
+  ): Decoder[Wrapper] =
+    decoder((index, row, session) => {
+      val obj = row.getObject(index, classOf[org.postgresql.util.PGobject])
+      val jsonString = obj.getValue
+      jsonDecoder.decodeJson(jsonString) match {
+        case Right(value) => wrap(value)
+        case Left(error)  => throw new IllegalArgumentException(s"Error decoding the Json value '${jsonString}' into a ${classTag[JsValue]}. Message: ${error}")
+      }
+    })
+}

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -104,7 +104,7 @@ abstract class ZioJdbcContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] e
    * However if it were used for something else it would be scoped to the fiber-ref of the zio-jdbc context's creator i.e. the global scope.
    */
   val currentConnection: FiberRef[Option[Connection]] =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(zio.Scope.global.extend(FiberRef.make(Option.empty[java.sql.Connection]))).getOrThrow()
     }
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
@@ -21,8 +21,7 @@ abstract class ZioJdbcUnderlyingContext[+Dialect <: SqlIdiom, +Naming <: NamingS
   with JdbcContextVerbExecute[Dialect, Naming]
   with ContextVerbStream[Dialect, Naming]
   with ZioPrepareContext[Dialect, Naming]
-  with ZioTranslateContext[Dialect, Naming]
-  {
+  with ZioTranslateContext[Dialect, Naming] {
 
   override private[getquill] val logger = ContextLogger(classOf[ZioJdbcUnderlyingContext[_, _]])
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/Quill.scala
@@ -12,65 +12,79 @@ import zio.{ Tag, ZIO, ZLayer }
 import java.io.Closeable
 import java.sql.{ Connection, SQLException }
 import javax.sql.DataSource
+import io.getquill.context.json.PostgresJsonExtensions
 
 object Quill {
-  case class Postgres[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class Postgres[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
+    extends Quill[PostgresDialect, N] with PostgresJdbcTypes[PostgresDialect, N] with PostgresJsonExtensions {
+    val idiom: PostgresDialect = PostgresDialect
+    val dsDelegate = new PostgresZioJdbcContext[N](naming)
+  }
+
+  /** Postgres ZIO Context without JDBC Encoders */
+  class PostgresLite[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[PostgresDialect, N] with PostgresJdbcTypes[PostgresDialect, N] {
     val idiom: PostgresDialect = PostgresDialect
     val dsDelegate = new PostgresZioJdbcContext[N](naming)
   }
 
   object Postgres {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new PostgresLite[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, Postgres[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Postgres[N](naming, ds))
   }
 
-  case class SqlServer[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class SqlServer[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[SQLServerDialect, N] with SqlServerJdbcTypes[SQLServerDialect, N] {
     val idiom: SQLServerDialect = SQLServerDialect
     val dsDelegate = new SqlServerZioJdbcContext[N](naming)
   }
   object SqlServer {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new SqlServer[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, SqlServer[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new SqlServer[N](naming, ds))
   }
 
-  case class H2[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class H2[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[H2Dialect, N] with H2JdbcTypes[H2Dialect, N] {
     val idiom: H2Dialect = H2Dialect
     val dsDelegate = new H2ZioJdbcContext[N](naming)
   }
   object H2 {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new H2[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, H2[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new H2[N](naming, ds))
   }
 
-  case class Mysql[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class Mysql[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[MySQLDialect, N] with MysqlJdbcTypes[MySQLDialect, N] {
     val idiom: MySQLDialect = MySQLDialect
     val dsDelegate = new MysqlZioJdbcContext[N](naming)
   }
   object Mysql {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Mysql[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, Mysql[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Mysql[N](naming, ds))
   }
 
-  case class Sqlite[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class Sqlite[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[SqliteDialect, N] with SqliteJdbcTypes[SqliteDialect, N] {
     val idiom: SqliteDialect = SqliteDialect
     val dsDelegate = new SqliteZioJdbcContext[N](naming)
   }
   object Sqlite {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Sqlite[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, Sqlite[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Sqlite[N](naming, ds))
   }
 
-  case class Oracle[+N <: NamingStrategy](naming: N, override val ds: DataSource)
+  class Oracle[+N <: NamingStrategy](val naming: N, override val ds: DataSource)
     extends Quill[OracleDialect, N] with OracleJdbcTypes[OracleDialect, N] {
     val idiom: OracleDialect = OracleDialect
     val dsDelegate = new OracleZioJdbcContext[N](naming)
   }
   object Oracle {
+    def apply[N <: NamingStrategy](naming: N, ds: DataSource) = new Oracle[N](naming, ds)
     def fromNamingStrategy[N <: NamingStrategy: Tag](naming: N): ZLayer[javax.sql.DataSource, Nothing, Oracle[N]] =
       ZLayer.fromFunction((ds: javax.sql.DataSource) => new Oracle[N](naming, ds))
   }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
@@ -10,7 +10,7 @@ import javax.sql.DataSource
 
 object ZioSpec {
   def runLayerUnsafe[T: Tag](layer: ZLayer[Any, Throwable, T]): T =
-    zio.Unsafe.unsafe {
+    zio.Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(zio.Scope.global.extend(layer.build)).getOrThrow()
     }.get
 }
@@ -21,12 +21,12 @@ trait ZioSpec extends Spec with BeforeAndAfterAll {
     stream.run(ZSink.collectAll).map(_.toList)
 
   def collect[T](stream: ZStream[Any, Throwable, T]): List[T] =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(stream.run(ZSink.collectAll).map(_.toList)).getOrThrow()
     }
 
   def collect[T](qzio: ZIO[Any, Throwable, T]): T =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(qzio).getOrThrow()
     }
 
@@ -48,18 +48,18 @@ trait ZioProxySpec extends Spec with BeforeAndAfterAll {
     stream.run(ZSink.collectAll).map(_.toList)
 
   def collect[T](stream: ZStream[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]): List[T] =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(stream.run(ZSink.collectAll).map(_.toList).provideEnvironment(ZEnvironment(runtime.env))).getOrThrow()
     }
 
   def collect[T](qzio: ZIO[DataSource, Throwable, T])(implicit runtime: Implicit[DataSource]): T =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(qzio.provideEnvironment(ZEnvironment(runtime.env))).getOrThrow()
     }
 
   implicit class ZioAnyOps[T](qzio: ZIO[Any, Throwable, T]) {
     def runSyncUnsafe() =
-      Unsafe.unsafe {
+      Unsafe.unsafe { implicit unsafe =>
         Runtime.default.unsafe.run(qzio).getOrThrow()
       }
   }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/IdiomaticAppPlain.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/IdiomaticAppPlain.scala
@@ -11,7 +11,7 @@ object IdiomaticAppPlain {
   import IdiomaticAppData.Application
 
   def main(args: Array[String]): Unit = {
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(
         (for {
           joes <- Application.getPeopleByName("Joe")

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainApp.scala
@@ -24,7 +24,7 @@ object PlainApp {
         .tap(result => zio.ZIO.attempt(println(result.toString)))
         .provideLayer(zioDS)
 
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(qzio).getOrThrow()
     }
     ()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainAppDataSource.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainAppDataSource.scala
@@ -29,7 +29,7 @@ object PlainAppDataSource {
         .tap(result => printLine(result.toString))
         .provide(zioDS)
 
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(qzio)
     }
     ()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainAppDataSource2.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/other/PlainAppDataSource2.scala
@@ -31,7 +31,7 @@ object PlainAppDataSource2 {
         .tap(result => printLine(result.toString))
         .provide(zioDS)
 
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       Runtime.default.unsafe.run(qzio)
     }
     ()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/StreamingWithFetchSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/StreamingWithFetchSpec.scala
@@ -18,7 +18,7 @@ class StreamingWithFetchSpec extends ZioProxySpec with BeforeAndAfter {
   inline def insert = quote { (p: Person) => query[Person].insertValue(p) }
 
   def result[T](qzio: QIO[T]): T =
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       qzio.provideEnvironment(ZEnvironment(io.getquill.postgres.pool)).runSyncUnsafe()
     }
 

--- a/quill-jdbc-zio/src/test/scala/io/getquill/mock/ZioMockSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/mock/ZioMockSpec.scala
@@ -63,7 +63,7 @@
 //     import ctx._
 
 //     val results =
-//       Unsafe.unsafe { implicit u =>
+//       Unsafe.unsafe { implicit unsafe => implicit u =>
 //         zio.Runtime.default.unsafe.run {
 //           stream(query[Person])
 //             .runFold(Seq[Person]())({ case (l, p) => p +: l })
@@ -107,7 +107,7 @@
 //     import ctx._
 
 //     val results =
-//       Unsafe.unsafe { implicit u =>
+//       Unsafe.unsafe { implicit unsafe => implicit u =>
 //         zio.Runtime.default.unsafe.run {
 //           ctx.run(query[Person])
 //             .provideEnvironment(ZEnvironment(ds))
@@ -137,7 +137,7 @@
 //     import ctx._
 
 //     val resultMsg =
-//       Unsafe.unsafe { implicit u =>
+//       Unsafe.unsafe { implicit unsafe => implicit u =>
 //         zio.Runtime.default.unsafe.run {
 //           stream(query[Person])
 //             .runFold(Seq[Person]())({ case (l, p) => p +: l })
@@ -175,7 +175,7 @@
 
 //     // In this case, instead of catching the error inside the observable, let it propogate to the top
 //     // and make sure that the connection is closed anyhow
-//     val resultMsg = Unsafe.unsafe { implicit u =>
+//     val resultMsg = Unsafe.unsafe { implicit unsafe => implicit u =>
 //       zio.Runtime.default.unsafe.run {
 //         stream(query[Person])
 //           .runFold(Seq[Person]())({ case (l, p) => p +: l })

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -31,7 +31,7 @@ class ConnectionLeakTest extends ProductSpec with ZioSpec {
 
   "insert and select without leaking" in {
     val result =
-      Unsafe.unsafe {
+      Unsafe.unsafe { implicit unsafe =>
         Runtime.default.unsafe.run(context.underlying.transaction {
           import context.underlying._
           for {

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/MultiLevelServiceSpec.scala
@@ -23,7 +23,7 @@ class MultiLevelServiceSpec extends AnyFreeSpec with BeforeAndAfterAll with Matc
     super.beforeAll()
     val testContext = new Quill.Postgres(Literal, io.getquill.postgres.pool)
     import testContext._
-    Unsafe.unsafe {
+    Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe.run(
         testContext.transaction {
           for {
@@ -76,7 +76,7 @@ class MultiLevelServiceSpec extends AnyFreeSpec with BeforeAndAfterAll with Matc
     val combinedLayer = dataSourceLive >>> postgresLive >>> dataServiceLive >>> applicationLive
 
     val (a, b, c, d, e) =
-      Unsafe.unsafe {
+      Unsafe.unsafe { implicit unsafe =>
         zio.Runtime.default.unsafe.run(
           (for {
             a <- Application.getJoes()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PostgresJsonSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/PostgresJsonSpec.scala
@@ -1,0 +1,72 @@
+package io.getquill.postgres
+
+import io.getquill._
+import zio.Chunk
+import zio.json.ast.Json
+import zio.json.{ DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder } //
+
+class PostgresJsonSpec extends ZioSpec {
+  val context = testContext
+  import testContext._
+
+  case class PersonJson(name: String, age: Int)
+  case class PersonJsonb(name: String, age: Int)
+
+  case class JsonEntity(name: String, value: JsonValue[PersonJson])
+  case class JsonbEntity(name: String, value: JsonbValue[PersonJsonb])
+
+  val jsonJoe = JsonValue(PersonJson("Joe", 123))
+  val jsonValue = JsonEntity("JoeEntity", jsonJoe)
+  val jsonbJoe = JsonbValue(PersonJsonb("Joe", 123))
+  val jsonbValue = JsonbEntity("JoeEntity", jsonbJoe)
+
+  case class JsonAstEntity(name: String, value: JsonValue[Json])
+  case class JsonbAstEntity(name: String, value: JsonbValue[Json])
+
+  implicit val personJsonEncoder: JsonEncoder[PersonJson] = DeriveJsonEncoder.gen[PersonJson]
+  implicit val personJsonDecoder: JsonDecoder[PersonJson] = DeriveJsonDecoder.gen[PersonJson]
+
+  implicit val personJsonbEncoder: JsonEncoder[PersonJsonb] = DeriveJsonEncoder.gen[PersonJsonb]
+  implicit val personJsonbDecoder: JsonDecoder[PersonJsonb] = DeriveJsonDecoder.gen[PersonJsonb]
+
+  override def beforeAll() = {
+    super.beforeAll()
+    testContext.run(quote(query[JsonbEntity].delete)).runSyncUnsafe()
+    testContext.run(quote(query[JsonEntity].delete)).runSyncUnsafe()
+    ()
+  }
+
+  "encodes and decodes json entity" - {
+    "json" in {
+      testContext.run(query[JsonEntity].insertValue(lift(jsonValue))).runSyncUnsafe()
+      val inserted = testContext.run(query[JsonEntity]).runSyncUnsafe().head
+      inserted mustEqual jsonValue
+    }
+
+    "jsonb" in {
+      testContext.run(query[JsonbEntity].insertValue(lift(jsonbValue))).runSyncUnsafe()
+      val inserted = testContext.run(query[JsonbEntity]).runSyncUnsafe().head
+      inserted mustEqual jsonbValue
+    }
+  }
+
+  "encodes and decodes json ast" - {
+    val jsonJoe = Json.Obj(Chunk("age" -> Json.Num(123), "name" -> Json.Str("Joe")))
+    inline def jsonAstQuery = quote { querySchema[JsonAstEntity]("JsonEntity") }
+    inline def jsonbAstQuery = quote { querySchema[JsonbAstEntity]("JsonbEntity") }
+
+    val jsonAstValue = JsonAstEntity("JoeEntity", JsonValue(jsonJoe))
+    val jsonbAstValue = JsonbAstEntity("JoeEntity", JsonbValue(jsonJoe))
+
+    "json" in {
+      testContext.run(jsonAstQuery.insertValue(lift(jsonAstValue))).runSyncUnsafe()
+      val inserted = testContext.run(jsonAstQuery).runSyncUnsafe().head
+      inserted mustEqual jsonAstValue
+    }
+    "jsonb" in {
+      testContext.run(jsonbAstQuery.insertValue(lift(jsonbAstValue))).runSyncUnsafe()
+      val inserted = testContext.run(jsonbAstQuery).runSyncUnsafe().head
+      inserted mustEqual jsonbAstValue
+    }
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -54,25 +54,11 @@ object QuatMaking:
 
   private val encodeableCache: mutable.Map[QuotesTypeRepr, Boolean] = mutable.Map()
   def lookupIsEncodeable(tpe: QuotesTypeRepr)(computeEncodeable: () => Boolean) =
-    val lookup = encodeableCache.get(tpe)
-    lookup match
-      case Some(value) =>
-        value
-      case None =>
-        val encodeable = computeEncodeable()
-        encodeableCache.put(tpe, encodeable)
-        encodeable
+    computeEncodeable()
 
   private val quatCache: mutable.Map[QuotesTypeRepr, Quat] = mutable.Map()
   def lookupCache(tpe: QuotesTypeRepr)(computeQuat: () => Quat) =
-    val lookup = quatCache.get(tpe)
-    lookup match
-      case Some(value) =>
-        value
-      case None =>
-        val quat = computeQuat()
-        quatCache.put(tpe, quat)
-        quat
+    computeQuat()
 
   enum AnyValBehavior:
     case TreatAsValue

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -23,6 +23,16 @@ CREATE TABLE Task(
     tsk VARCHAR(255)
 );
 
+CREATE TABLE JsonbEntity(
+     name VARCHAR(255),
+     value JSONB
+);
+
+CREATE TABLE JsonEntity(
+    name VARCHAR(255),
+    value JSON
+);
+
 CREATE TABLE TimeEntity(
     sqlDate        DATE,                     -- java.sql.Date
     sqlTime        TIME,                     -- java.sql.Time


### PR DESCRIPTION
* Add support for Json/Jsonb columns in postgres in the quill-jdbc-zio context via zio-json.
* Needed to bump ZIO to 2.0.2 in order to bring in zio-json 0.3.0.