### PR TITLE
JDBC DataSource should not need to be closeable

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, H2JdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class H2JdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[H2Dialect, N]
   with H2JdbcContextBase[H2Dialect, N] {
   override val idiom: H2Dialect = H2Dialect

--- a/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, MysqlJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class MysqlJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[MySQLDialect, N]
   with MysqlJdbcContextBase[MySQLDialect, N] {
   override val idiom: MySQLDialect = MySQLDialect

--- a/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/OracleJdbcContext.scala
@@ -7,7 +7,7 @@ import io.getquill.context.jdbc.{ JdbcContext, OracleJdbcContextBase }
 import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
-class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class OracleJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[OracleDialect, N]
   with OracleJdbcContextBase[OracleDialect, N] {
   override val idiom: OracleDialect = OracleDialect

--- a/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, PostgresJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class PostgresJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[PostgresDialect, N]
   with PostgresJdbcContextBase[PostgresDialect, N] {
   override val idiom: PostgresDialect = PostgresDialect

--- a/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqlServerJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqlServerJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqlServerJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[SQLServerDialect, N]
   with SqlServerJdbcContextBase[SQLServerDialect, N] {
   override val idiom: SQLServerDialect = SQLServerDialect

--- a/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.Config
 import io.getquill.context.jdbc.{ JdbcContext, SqliteJdbcContextBase }
 import io.getquill.util.LoadConfig
 
-class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource with Closeable)
+class SqliteJdbcContext[+N <: NamingStrategy](val naming: N, val dataSource: DataSource)
   extends JdbcContext[SqliteDialect, N]
   with SqliteJdbcContextBase[SqliteDialect, N] {
   override val idiom: SqliteDialect = SqliteDialect


### PR DESCRIPTION
JDBC DataSource should not need to be closeable. Can check if it is and close if possible. Otherwise warn that it isn't.