### PR TITLE
Update quill-jasync-postgres to use jasync-postgres 2.1.8 instead of 2.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,7 @@ lazy val `quill-jasync-postgres` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.jasync-sql" % "jasync-postgresql" % "2.0.6"
+        "com.github.jasync-sql" % "jasync-postgresql" % "2.1.8"
       )
     )
     .dependsOn(`quill-jasync` % "compile->compile;test->test")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.6.1-SNAPSHOT"
+ThisBuild / version := "4.6.1-SNAPSHOT"


### PR DESCRIPTION
### Problem

There are three serious vulnerabilities in netty-codec, used upstream, reported to me by checkmarx:

- CVE-2021-37136 7.5 Uncontrolled Resource Consumption vulnerability pending CVSS allocation
- CVE-2021-37137 7.5 Uncontrolled Resource Consumption vulnerability pending CVSS allocation
- CVE-2022-41915 6.5 Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting') vulnerability with medium severity found


### Solution

Updated the dependency to latest minor.

### Notes

Also fixed an sbt syntax deprecation warning

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable <-- not applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes <-- can't we just squash and merge upon accepting the PR? built into Github nowadays

@getquill/maintainers
