### PR TITLE
Add encoding for UUID arrays in Postgres

### DIFF
--- a/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayDecoders.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayDecoders.scala
@@ -3,6 +3,7 @@ package io.getquill.context.jasync
 import java.time.{ LocalDate, LocalDateTime, ZoneId }
 import java.util
 import java.util.Date
+import java.util.UUID
 import io.getquill.{ PostgresJAsyncContext, PostgresJAsyncContextBase }
 import io.getquill.generic.ArrayEncoding
 import io.getquill.util.Messages.fail
@@ -26,6 +27,7 @@ trait ArrayDecoders extends ArrayEncoding {
   implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = arrayDecoder[LocalDateTime, Date, Col](d => Date.from(d.atZone(ZoneId.systemDefault()).toInstant))
   implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = arrayRawDecoder[LocalDate, Col]
   implicit def arrayLocalDateTimeDecoder[Col <: Seq[LocalDateTime]](implicit bf: CBF[LocalDateTime, Col]): Decoder[Col] = arrayRawDecoder[LocalDateTime, Col]
+  implicit def arrayUuidDecoder[Col <: Seq[UUID]](implicit bf: Factory[UUID, Col]): Decoder[Col] = arrayRawDecoder[UUID, Col]
 
   def arrayDecoder[I, O, Col <: Seq[O]](mapper: I => O)(implicit bf: CBF[O, Col], iTag: ClassTag[I], oTag: ClassTag[O]): Decoder[Col] =
     AsyncDecoder[Col](SqlTypes.ARRAY)(new BaseDecoder[Col] {

--- a/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayEncoders.scala
+++ b/quill-jasync-postgres/src/main/scala/io/getquill/context/jasync/ArrayEncoders.scala
@@ -3,6 +3,7 @@ package io.getquill.context.jasync
 import java.sql.Timestamp
 import java.time.{ LocalDate, LocalDateTime, OffsetDateTime }
 import java.util.Date
+import java.util.UUID
 import io.getquill.{ PostgresJAsyncContext, PostgresJAsyncContextBase }
 import io.getquill.generic.ArrayEncoding
 
@@ -21,6 +22,7 @@ trait ArrayEncoders extends ArrayEncoding {
   implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = arrayEncoder[Date, Col](date => OffsetDateTime.ofInstant(date.toInstant, dateTimeZone).toLocalDateTime)
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayRawEncoder[LocalDate, Col]
   implicit def arrayLocalDateTimeEncoder[Col <: Seq[LocalDateTime]]: Encoder[Col] = arrayRawEncoder[LocalDateTime, Col]
+  implicit def arrayUuidEncoder[Col <: Seq[UUID]]: Encoder[Col] = arrayRawEncoder[UUID, Col]
 
   def arrayEncoder[T, Col <: Seq[T]](mapper: T => Any): Encoder[Col] =
     encoder[Col]((col: Col) => col.toIndexedSeq.map(mapper).mkString("{", ",", "}"), SqlTypes.ARRAY)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
@@ -3,6 +3,7 @@ package io.getquill.context.jdbc
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.util.Date
+import java.util.UUID
 import java.sql.{ Date => SqlDate }
 import java.math.{ BigDecimal => JBigDecimal }
 
@@ -28,6 +29,7 @@ trait ArrayDecoders extends ArrayEncoding {
   implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = arrayRawDecoder[Date, Col]
   implicit def arrayTimestampDecoder[Col <: Seq[Timestamp]](implicit bf: CBF[Timestamp, Col]): Decoder[Col] = arrayRawDecoder[Timestamp, Col]
   implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = arrayDecoder[SqlDate, LocalDate, Col](_.toLocalDate)
+  implicit def arrayUuidDecoder[Col <: Seq[UUID]](implicit bf: Factory[UUID, Col]): Decoder[Col] = arrayRawDecoder[UUID, Col]
 
   /**
    * Generic encoder for JDBC arrays.

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
@@ -4,6 +4,7 @@ import java.sql.{ Timestamp, Date => SqlDate }
 import java.sql.Types._
 import java.time.LocalDate
 import java.util.Date
+import java.util.UUID
 
 import io.getquill.generic.ArrayEncoding
 import scala.collection.compat._
@@ -23,6 +24,7 @@ trait ArrayEncoders extends ArrayEncoding {
   implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = arrayRawEncoder[Date, Col](TIMESTAMP)
   implicit def arrayTimestampEncoder[Col <: Seq[Timestamp]]: Encoder[Col] = arrayRawEncoder[Timestamp, Col](TIMESTAMP)
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayEncoder[LocalDate, Col](parseJdbcType(DATE), SqlDate.valueOf)
+  implicit def arrayUuidEncoder[Col <: Seq[UUID]]: Encoder[Col] = arrayRawEncoder[UUID, Col]("uuid")
 
   /**
    * Generic encoder for JDBC arrays.

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
@@ -35,18 +35,6 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
     ctx.run(tQ).head.timestamps mustBe tE.timestamps
   }
 
-  "Custom decoders/encoders" in {
-    case class Entity(uuids: List[UUID])
-    val e = Entity(List(UUID.randomUUID(), UUID.randomUUID()))
-    val q = quote(querySchema[Entity]("ArraysTestEntity"))
-
-    implicit def arrayUUIDEncoder[Col <: Seq[UUID]]: Encoder[Col] = arrayRawEncoder[UUID, Col]("uuid")
-    implicit def arrayUUIDDecoder[Col <: Seq[UUID]](implicit bf: CBF[UUID, Col]): Decoder[Col] = arrayRawDecoder[UUID, Col]
-
-    ctx.run(q.insertValue(lift(e)))
-    ctx.run(q).head.uuids mustBe e.uuids
-  }
-
   "Arrays in where clause" in {
     ctx.run(q.insertValue(lift(corrected)))
     val actual1 = ctx.run(q.filter(_.texts == lift(List("test"))))

--- a/quill-sql/src/main/scala/io/getquill/context/mirror/ArrayMirrorEncoding.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/mirror/ArrayMirrorEncoding.scala
@@ -2,9 +2,12 @@ package io.getquill.context.mirror
 
 import java.time.LocalDate
 import java.util.Date
+import java.util.UUID
 
 import io.getquill.SqlMirrorContext
 import io.getquill.generic.ArrayEncoding
+
+import scala.collection.Factory
 
 trait ArrayMirrorEncoding extends ArrayEncoding {
   this: SqlMirrorContext[_, _] =>
@@ -20,6 +23,7 @@ trait ArrayMirrorEncoding extends ArrayEncoding {
   implicit def arrayDoubleEncoder[Col <: Seq[Double]]: Encoder[Col] = encoder[Col]
   implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = encoder[Col]
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = encoder[Col]
+  implicit def arrayUuidEncoder[Col <: Seq[UUID]]: Encoder[Col] = encoder[Col]
 
   implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CBF[String, Col]): Decoder[Col] = decoderUnsafe[Col]
   implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = decoderUnsafe[Col]
@@ -32,4 +36,5 @@ trait ArrayMirrorEncoding extends ArrayEncoding {
   implicit def arrayDoubleDecoder[Col <: Seq[Double]](implicit bf: CBF[Double, Col]): Decoder[Col] = decoderUnsafe[Col]
   implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = decoderUnsafe[Col]
   implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayUuidDecoder[Col <: Seq[UUID]](implicit bf: Factory[UUID, Col]): Decoder[Col] = decoderUnsafe[Col]
 }

--- a/quill-sql/src/main/scala/io/getquill/generic/ArrayEncoding.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/ArrayEncoding.scala
@@ -2,6 +2,7 @@ package io.getquill.generic
 
 import java.time.LocalDate
 import java.util.Date
+import java.util.UUID
 
 //import io.getquill.context.sql.SqlContext
 
@@ -27,6 +28,7 @@ trait ArrayEncoding extends EncodingDsl {
   implicit def arrayDoubleEncoder[Col <: Seq[Double]]: Encoder[Col]
   implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col]
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col]
+  implicit def arrayUuidEncoder[Col <: Seq[UUID]]: Encoder[Col]
 
   implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CBF[String, Col]): Decoder[Col]
   implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col]
@@ -39,6 +41,7 @@ trait ArrayEncoding extends EncodingDsl {
   implicit def arrayDoubleDecoder[Col <: Seq[Double]](implicit bf: CBF[Double, Col]): Decoder[Col]
   implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col]
   implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col]
+  implicit def arrayUuidDecoder[Col <: Seq[UUID]](implicit bf: Factory[UUID, Col]): Decoder[Col]
 
   implicit def arrayMappedEncoder[I, O, Col[X] <: Seq[X]](
       implicit

--- a/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.context.sql.encoding
 
 import java.time.LocalDate
 import java.util.Date
+import java.util.UUID
 
 import io.getquill.{MappedEncoding, Spec}
 import org.scalatest.{Assertion, BeforeAndAfterEach}
@@ -20,7 +21,8 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
       floats: Seq[Float],
       doubles: Seq[Double],
       timestamps: Seq[Date],
-      dates: Seq[LocalDate]
+      dates: Seq[LocalDate],
+      uuids: Seq[UUID]
   )
 
   val e = ArraysTestEntity(
@@ -34,7 +36,8 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
     Seq(1f, 2f),
     Seq(4d, 3d),
     Seq(new Date(System.currentTimeMillis())),
-    Seq(LocalDate.now())
+    Seq(LocalDate.now()),
+    Seq(UUID.randomUUID())
   )
 
   // casting types can be dangerous so we need to ensure that everything is ok
@@ -50,6 +53,7 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
     e1.doubles.head mustBe e2.doubles.head
     e1.timestamps.head mustBe e2.timestamps.head
     e1.dates.head mustBe e2.dates.head
+    e1.uuids.head mustBe e2.uuids.head
   }
 
   // Support Seq encoding basing on MappedEncoding


### PR DESCRIPTION
### Problem

Quill does not have built-in support for arrays of UUIDs.

### Solution

I have added encoders and decoders for arrays of UUIDs in Postgres for quill-jdbc and quill-jasync-postgres.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
