### PR TITLE
Fix JDBC Instant encoder

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -101,13 +101,13 @@ trait BasicTimeEncoders extends Encoders {
     encoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, value, row) =>
       row.setTimestamp(index, Timestamp.from(value.toInstant)))
   implicit val instantEncoder: Encoder[Instant] =
-    encoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, value, row) =>
+    encoder(Types.TIMESTAMP, (index, value, row) =>
       row.setTimestamp(index, Timestamp.from(value)))
 
-  implicit val offseTimeEncoder: Encoder[OffsetTime] =
+  implicit val offsetTimeEncoder: Encoder[OffsetTime] =
     encoder(Types.TIME, (index, value, row) =>
       row.setTime(index, java.sql.Time.valueOf(value.withOffsetSameInstant(ZoneOffset.UTC).toLocalTime)))
-  implicit val offseDateTimeEncoder: Encoder[OffsetDateTime] =
+  implicit val offsetDateTimeEncoder: Encoder[OffsetDateTime] =
     encoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, value, row) =>
       row.setTimestamp(index, java.sql.Timestamp.from(value.toInstant)))
 }


### PR DESCRIPTION
- Instants don't have time zones.
- Fix small typo.
