### PR TITLE
Remove unneccessary logging in DynamicDsl

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/DynamicDslModel.scala
+++ b/quill-sql/src/main/scala/io/getquill/DynamicDslModel.scala
@@ -134,7 +134,6 @@ sealed class DynamicQuery[+T](val q: Quoted[Query[T]]) {
           q.runtimeQuotes
         )
       )
-    println(io.getquill.util.Messages.qprint(out))
     out
 
   def takeOpt(opt: Option[Int])(implicit enc: GenericEncoder[Int, _, _]): DynamicQuery[T] =


### PR DESCRIPTION
Fixes #issue_number

### Problem

Calling `.take(n)` on dynamic query produce unwanted log messages when run.

### Solution

Remove `println` that seems unneccessary to be there.

@getquill/maintainers
