### PR TITLE
Avoid running each CI step twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,12 @@
 name: Scala CI
 
 on:
+  pull_request:
   push:
     branches:
-      - "**"
-    # tags:
-    #   - "**"
-
-  pull_request:
-    branches:
       - master
+      - 're-releases-*'
+      - '*-pushbuild'
 
 env:
   JAVA_OPTS: -Xms6g -Xmx6g -XX:+UseG1GC


### PR DESCRIPTION
Avoids the duplicates we can see on this screenshot (notice that each job is duplicated twice, one for `pull_request` and one for `push`)

<img width="843" alt="Screenshot 2023-09-04 at 7 01 58 pm" src="https://github.com/zio/zio-protoquill/assets/1193670/04f8b021-67c2-4a35-85e7-bc81b2016bf8">

(Screenshot took on https://github.com/zio/zio-protoquill/pull/323)