### PR TITLE
Remove config from exception when Hikari data source can't be created

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContextConfig.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContextConfig.scala
@@ -22,6 +22,6 @@ case class JdbcContextConfig(config: Config) {
       new HikariDataSource(new HikariConfig(configProperties))
     catch {
       case NonFatal(ex) =>
-        throw new IllegalStateException(s"Failed to load data source for config: '$config'", ex)
+        throw new IllegalStateException("Failed to load data source", ex)
     }
 }


### PR DESCRIPTION
### Problem

The config with password is printed in logs when an application can't establish a JDBC connection.

The exact same thing was fixed here: https://github.com/zio/zio-quill/pull/2503
This PR is targeted for Scala 3.

### Solution

Remove printing config to stacktrace so that it's fixed in Scala 3 as well.

### Notes

Am I right that it will fix the issue for Scala 3?

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
