### PR TITLE
Arbitrary arity tuple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         module: [ sqltest, db, bigdata ]
 
     steps:
-      - uses: actions/checkout@v4.1.2
+      - uses: actions/checkout@v4.1.3
       - name: Setup Java and Scala
         uses: actions/setup-java@v4.2.1
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4.1.2
+      - uses: actions/checkout@v4.1.3
       - name: Setup Java and Scala
         uses: actions/setup-java@v4.2.1
         with:

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
@@ -385,46 +385,7 @@ object ConstructDecoded {
       '{EmptyTuple}
     } else if (tpe <:< TypeRepr.of[Tuple]) {
       '{scala.runtime.Tuples.fromIArray(IArray(${Varargs(terms)})).asInstanceOf[T]}
-      // Alternative version:
-      // val t = 
-      //   Varargs
-      // Type.of[T] match {
-      //   case '[h *: t] =>
-      //     val construct = Type.of[t] match {
-      //       case '[EmptyTuple] =>
-      //         println(" ConstructDecoded: t=et")
-      //         Apply(
-      //           TypeApply(
-      //             Select(New(TypeTree.of[Tuple1[h]]), constructor),
-      //             types.map { tpe =>
-      //               tpe match {
-      //                 case '[tt] => TypeTree.of[tt]
-      //               }
-      //             }
-      //           ),
-      //           terms.map(_.asTerm)
-      //         )
-      //       case _ =>
-      //         val typeTrees = types.map { tpe =>
-      //               tpe match {
-      //                 case '[tt] => TypeTree.of[tt]
-      //               }
-      //             }
-      //         val terms2 = terms.map(_.asTerm)
-      //         val ttt = TypeTree.of[T]
-              
-      //         println(s" ConstructDecoded: t=t; ttt = $ttt; typeTrees = $typeTrees; terms2 = $terms2")
-      //         Apply(
-      //           Select(New(TypeTree.of[IArray[Object]]), constructor),
-      //           // VarArgs
-      //           terms2
-      //         )
-      //     }
-      //     println(s"=========== Create from Tuple Constructor: Tree: $construct ===========")
-      //     println(s"=========== Create from Tuple Constructor ${Format.Expr(construct.asExprOf[T])} ===========")
-      //     construct.asExprOf[T]
-      //     // If we are a case class with no generic parameters, we can easily construct it
-      // }
+      // If we are a case class with no generic parameters, we can easily construct it
     } else if (tpe.classSymbol.exists(_.flags.is(Flags.Case)) && !constructor.paramSymss.exists(_.exists(_.isTypeParam))) {
       val construct =
         Apply(

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
@@ -187,7 +187,7 @@ object GenericDecoder {
     // they will be the constructor and/or any other field-decoders:
     // List((new Name(Decoder("Joe") || Decoder("Bloggs")), Decoder(123))
     // This is what needs to be fed into the constructor of the outer-entity i.e.
-    // new Person((new Name(Decoder("Joe") || Decoder("Bloggs")), DecodConstructDecodeder(123))
+    // new Person((new Name(Decoder("Joe") || Decoder("Bloggs")), Decoder(123))
     val productElements = flattenData.map(_.decodedExpr)
     // actually doing the construction i.e. `new Person(...)`
     val constructed = ConstructDecoded[T](types, productElements, m)
@@ -381,6 +381,7 @@ object ConstructDecoded {
       '{EmptyTuple}
     } else if (tpe <:< TypeRepr.of[Tuple]) {
       '{scala.runtime.Tuples.fromIArray(IArray(${Varargs(terms)})).asInstanceOf[T]}
+      // Alternative version:
       // val t = 
       //   Varargs
       // Type.of[T] match {

--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -199,21 +199,9 @@ object ArbitraryTupleConstructionInlined {
     t match {
       case
         Inlined(
-        //  Some(Apply(
-        //    TypeApply(
-        //      Select(
-        //        Inlined(_,_,
-        //          Typed(AsInstanceOf(TupleCons(a,b)), _)
-        //        ),
-        //        "*:"
-        //      ),
-        //      _
-        //    ),
-        //    _
-        //  )),
-        _,
-        List(ValDef("Tuple_this", _, Some(prevTuple))),
-        Typed(AsInstanceOf(TupleCons(head, TIdent("Tuple_this"))), _)
+          _,
+          List(ValDef("Tuple_this", _, Some(prevTuple))),
+          Typed(AsInstanceOf(TupleCons(head, TIdent("Tuple_this"))), _)
         ) =>
         Some((head, prevTuple))
       case _ => None
@@ -254,7 +242,6 @@ class ArbitraryTupleBlockParser(val rootParse: Parser)(using Quotes, TranspileCo
       val aAst = rootParse(a)
       ast.Tuple(List(aAst))
     case inlined@Unseal(ArbitraryTupleConstructionInlined(singleValue, prevTuple)) =>
-      //printExpr(inlined, "singleValue ArbitraryTupleConstructionInlined")
       val headAst = rootParse(singleValue.asExpr)
       val prevTupleAst = rootParse(prevTuple.asExpr)
       prevTupleAst match {
@@ -263,7 +250,6 @@ class ArbitraryTupleBlockParser(val rootParse: Parser)(using Quotes, TranspileCo
           throw IllegalArgumentException(s"Unexpected tuple ast ${prevTupleAst}")
       }
     case block@Unseal(TBlock(parts, ArbitraryTupleConstructionInlined(head,Typed(AsInstanceOf(TupleCons(head2,TIdent("Tuple_this"))), _)) )) if (parts.length > 0) =>
-      //println(s"Large block. parts.size=${parts.size}; parts:\n- ${parts.mkString("\n- ")}")
       val headAst = rootParse(head.asExpr)
       val head2Ast = rootParse(head2.asExpr)
       val partsAsts = headAst :: head2Ast :: parts.reverse.flatMap{

--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -53,6 +53,7 @@ trait ParserLibrary extends ParserFactory {
   protected def functionParser(using Quotes, TranspileConfig) = ParserChain.attempt(FunctionParser(_))
   protected def functionApplyParser(using Quotes, TranspileConfig) = ParserChain.attempt(FunctionApplyParser(_))
   protected def valParser(using Quotes, TranspileConfig) = ParserChain.attempt(ValParser(_))
+  protected def arbitraryTupleParser(using Quotes, TranspileConfig) = ParserChain.attempt(ArbitraryTupleBlockParser(_))
   protected def blockParser(using Quotes, TranspileConfig) = ParserChain.attempt(BlockParser(_))
   protected def extrasParser(using Quotes, TranspileConfig) = ParserChain.attempt(ExtrasParser(_))
   protected def operationsParser(using Quotes, TranspileConfig) = ParserChain.attempt(OperationsParser(_))
@@ -88,6 +89,7 @@ trait ParserLibrary extends ParserFactory {
         .orElse(functionParser) // decided to have it be it's own parser unlike Quill3
         .orElse(patMatchParser)
         .orElse(valParser)
+        .orElse(arbitraryTupleParser)
         .orElse(blockParser)
         .orElse(operationsParser)
         .orElse(extrasParser)
@@ -151,6 +153,126 @@ class ValParser(val rootParse: Parser)(using Quotes, TranspileConfig)
   import quotes.reflect._
   def attempt = {
     case Unseal(ValDefTerm(ast)) => ast
+  }
+}
+/**
+ * Matches `runtime.Tuples.cons(head,tail)`.
+ */
+object TupleCons {
+  def unapply(using Quotes)(t: quotes.reflect.Term): Option[(quotes.reflect.Term, quotes.reflect.Term)] = {
+    import quotes.reflect.*
+    t match {
+      case Apply(Select(Select(Ident("runtime"), "Tuples"), "cons"), List(head, tail)) =>
+        Some((head, tail))
+      case _ =>
+        None
+    }
+  }
+}
+
+/**
+ * Matches inner.asInstanceOf[T]: T
+ */
+object AsInstanceOf {
+  def unapply(using Quotes)(term: quotes.reflect.Term): Option[quotes.reflect.Term] = {
+    import quotes.reflect._
+    term match {
+      case TypeApply(Select(inner, "asInstanceOf"), _) => Some(inner)
+      case _ => None
+    }
+  }
+}
+
+/**
+ * Matches an inlined call to `Tuple.*:`:
+ * {{{
+ * {
+ *   val Tuple_this: scala.Tuple$package.EmptyTuple.type = scala.Tuple$package.EmptyTuple
+ *
+ *   (scala.runtime.Tuples.cons(i, Tuple_this).asInstanceOf[scala.*:[scala.Int, scala.Tuple$package.EmptyTuple.type]]: scala.*:[scala.Int, scala.Tuple$package.EmptyTuple])
+ * }
+ * }}}
+ */
+object ArbitraryTupleConstructionInlined {
+  def unapply(using Quotes)(t: quotes.reflect.Term): Option[(quotes.reflect.Term, quotes.reflect.Term)] = {
+    import quotes.reflect.{Ident => TIdent, *}
+    t match {
+      case
+        Inlined(
+        //  Some(Apply(
+        //    TypeApply(
+        //      Select(
+        //        Inlined(_,_,
+        //          Typed(AsInstanceOf(TupleCons(a,b)), _)
+        //        ),
+        //        "*:"
+        //      ),
+        //      _
+        //    ),
+        //    _
+        //  )),
+        _,
+        List(ValDef("Tuple_this", _, Some(prevTuple))),
+        Typed(AsInstanceOf(TupleCons(head, TIdent("Tuple_this"))), _)
+        ) =>
+        Some((head, prevTuple))
+      case _ => None
+    }
+  }
+}
+
+/**
+ * Parses a few cases of arbitrary tuples.
+ *
+ * Scala 3 produces a few different trees for arbitrary tuples. Method `*:` is marked as inline.
+ * Under the hood it actually invokes `Tuples.cons` function:
+ * {{{
+ *     inline def *: [H, This >: this.type <: Tuple] (x: H): H *: This =
+ *       runtime.Tuples.cons(x, this).asInstanceOf[H *: This]
+ * }}}
+ * So, at least we have to match Tuples.cons.
+ * However, it's not the only variation. Scala also produces a block with intermediate val `Tuple_this` definitions:
+ * {{{
+ *   {
+ *     val Tuple_this: scala.Tuple$package.EmptyTuple.type = scala.Tuple$package.EmptyTuple
+ *     val `Tuple_this₂`: scala.*:[java.lang.String, scala.Tuple$package.EmptyTuple] = (scala.runtime.Tuples.cons("", Tuple_this).asInstanceOf[scala.*:[java.lang.String, scala.Tuple$package.EmptyTuple.type]]: scala.*:[java.lang.String, scala.Tuple$package.EmptyTuple])
+ *
+ *     (scala.runtime.Tuples.cons(1, `Tuple_this₂`).asInstanceOf[scala.*:[scala.Int, scala.*:[java.lang.String, scala.Tuple$package.EmptyTuple]]]: scala.*:[scala.Int, scala.*:[java.lang.String, scala.Tuple$package.EmptyTuple]])
+ *   }
+ * }}}
+ */
+class ArbitraryTupleBlockParser(val rootParse: Parser)(using Quotes, TranspileConfig)
+  extends Parser(rootParse)
+    with PatternMatchingValues {
+
+  import quotes.reflect.{Block => TBlock, Ident => TIdent, _}
+
+  def attempt = {
+    case '{EmptyTuple} =>
+      ast.Tuple(List())
+    case '{$a *: EmptyTuple} =>
+      val aAst = rootParse(a)
+      ast.Tuple(List(aAst))
+    case inlined@Unseal(ArbitraryTupleConstructionInlined(singleValue, prevTuple)) =>
+      //printExpr(inlined, "singleValue ArbitraryTupleConstructionInlined")
+      val headAst = rootParse(singleValue.asExpr)
+      val prevTupleAst = rootParse(prevTuple.asExpr)
+      prevTupleAst match {
+        case ast.Tuple(lst) => ast.Tuple(headAst :: lst)
+        case _ =>
+          throw IllegalArgumentException(s"Unexpected tuple ast ${prevTupleAst}")
+      }
+    case block@Unseal(TBlock(parts, ArbitraryTupleConstructionInlined(head,Typed(AsInstanceOf(TupleCons(head2,TIdent("Tuple_this"))), _)) )) if (parts.length > 0) =>
+      //println(s"Large block. parts.size=${parts.size}; parts:\n- ${parts.mkString("\n- ")}")
+      val headAst = rootParse(head.asExpr)
+      val head2Ast = rootParse(head2.asExpr)
+      val partsAsts = headAst :: head2Ast :: parts.reverse.flatMap{
+        case ValDef("Tuple_this", tpe, Some(TIdent("EmptyTuple"))) => List()
+        case ValDef("Tuple_this", tpe, Some(Typed(AsInstanceOf(TupleCons(next,TIdent("Tuple_this"))), _))) => List(rootParse(next.asExpr))
+        case ValDef("Tuple_this", tpe, Some(unknown)) =>
+          throw IllegalArgumentException(s"Unexpected Tuple_this = ${unknown.show}")
+      }
+      Tuple(partsAsts)
   }
 }
 

--- a/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
@@ -490,6 +490,12 @@ object ParserHelpers {
             binds.zipWithIndex.flatMap { case (bind, idx) =>
               tupleBindsPath(bind, path :+ s"_${idx + 1}")
             }
+          case Unapply(TypeApply(Select(TIdent("*:"), "unapply"), types), implicits, List(h, t)) =>
+            List(
+              tupleBindsPath(h, path :+ s"head"),
+              tupleBindsPath(h, path :+ s"tail")
+            )
+              .flatten
           // If it's a "case _ => ..." then that just translates into the body expression so we don't
           // need a clause to beta reduction over the entire partial-function
           case TIdent("_") =>

--- a/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -187,6 +187,25 @@ trait QuatMakingBase {
           None
     }
 
+    object ArbitraryArityTupleType {
+      def unapply(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[List[quotes.reflect.TypeRepr]] =
+        if (tpe.is[Tuple])
+          Some(tupleParts(tpe))
+        else
+          None
+
+      @tailrec
+      def tupleParts(using Quotes)(tpe: quotes.reflect.TypeRepr, accum: List[quotes.reflect.TypeRepr] = Nil): List[quotes.reflect.TypeRepr] =
+        tpe.asType match {
+            case '[h *: t] =>
+              val htpe = quotes.reflect.TypeRepr.of[h]
+              val ttpe = quotes.reflect.TypeRepr.of[t]
+              tupleParts(ttpe, htpe :: accum)
+            case '[EmptyTuple] =>
+              accum.reverse
+          }
+    }
+
     object OptionType {
       def unapply(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] = {
         import quotes.reflect._
@@ -381,6 +400,10 @@ trait QuatMakingBase {
           case CaseClassBaseType(name, fields) if !existsEncoderFor(tpe) || tpe <:< TypeRepr.of[Udt] =>
             Quat.Product(name, fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
 
+          case ArbitraryArityTupleType(tupleParts) =>
+            Quat.Product("Tuple", tupleParts.zipWithIndex.map { case (fieldType, idx) => (s"_${idx + 1}", parseType(fieldType)) })
+
+            //Quat.Product
           // If we are already inside a bounded type, treat an arbitrary type as a interface list
           case ArbitraryBaseType(name, fields) if (boundedInterfaceType) =>
             Quat.Product(name, fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })

--- a/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -403,7 +403,6 @@ trait QuatMakingBase {
           case ArbitraryArityTupleType(tupleParts) =>
             Quat.Product("Tuple", tupleParts.zipWithIndex.map { case (fieldType, idx) => (s"_${idx + 1}", parseType(fieldType)) })
 
-            //Quat.Product
           // If we are already inside a bounded type, treat an arbitrary type as a interface list
           case ArbitraryBaseType(name, fields) if (boundedInterfaceType) =>
             Quat.Product(name, fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })

--- a/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
@@ -33,4 +33,21 @@ class ArbitraryTupleSpec extends Spec {
       (123, "St")
   }
 
+  "get field of arbitrary long tuple" in {
+    inline def q = quote{
+      querySchema[MyRow2]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+    }
+
+    inline def g = quote{
+      q.map{t => t match {
+          case h *: tail => h
+        }
+      }
+    }
+    val result = ctx.run(g)
+
+    result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
+      (123)
+  }
+
 }

--- a/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill
+
+import io.getquill.context.mirror.{MirrorSession, Row}
+import io.getquill.generic.TupleMember
+
+class ArbitraryTupleSpec extends Spec {
+
+  val ctx = new MirrorContext(PostgresDialect, Literal)
+  import ctx._
+
+  type MyRow1 = (Int, String)
+  type MyRow2 = Int *: String *: EmptyTuple
+
+  "ordinary tuple" in {
+    inline def q = quote{
+      querySchema[MyRow1]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+    }
+
+    val result = ctx.run(q)
+
+    result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
+      (123, "St")
+  }
+
+  "arbitrary long tuple" in {
+    inline def q = quote{
+      querySchema[MyRow2]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+    }
+
+    val result = ctx.run(q)
+
+    result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
+      (123, "St")
+  }
+
+}

--- a/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/ArbitraryTupleSpec.scala
@@ -1,5 +1,6 @@
 package io.getquill
 
+import io.getquill.context.ExecutionType.Static
 import io.getquill.context.mirror.{MirrorSession, Row}
 import io.getquill.generic.TupleMember
 
@@ -11,37 +12,47 @@ class ArbitraryTupleSpec extends Spec {
   type MyRow1 = (Int, String)
   type MyRow2 = Int *: String *: EmptyTuple
 
+  inline def myRow1Query = quote {
+    querySchema[MyRow1]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+  }
+
+  inline def myRow2Query = quote {
+    querySchema[MyRow2]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+  }
+
   "ordinary tuple" in {
-    inline def q = quote{
-      querySchema[MyRow1]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
-    }
+    val result = ctx.run(myRow1Query)
 
-    val result = ctx.run(q)
-
+    result.string mustEqual "SELECT x.int_field, x.string_field FROM my_table x"
     result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
       (123, "St")
   }
 
-  "arbitrary long tuple" in {
-    inline def q = quote{
-      querySchema[MyRow2]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
+  "ordinary tuple swap" in {
+
+    transparent inline def swapped: Quoted[EntityQuery[(String, Int)]] = quote {
+      myRow1Query.map {
+        case (i, s) => (s, i)
+      }
     }
 
-    val result = ctx.run(q)
+    val result = ctx.run(swapped)
+
+    result.string mustEqual "SELECT x$1.string_field AS _1, x$1.int_field AS _2 FROM my_table x$1"
+    require(result.extractor(Row("St", 123), MirrorSession.default) == ("St", 123))
+  }
+
+  "arbitrary long tuple" in {
+    val result = ctx.run(myRow2Query)
 
     result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
       (123, "St")
   }
 
   "get field of arbitrary long tuple" in {
-    inline def q = quote{
-      querySchema[MyRow2]("my_table", t => t._1 -> "int_field", t => t._2 -> "string_field")
-    }
-
     inline def g = quote{
-      q.map{t => t match {
-          case h *: tail => h
-        }
+      myRow2Query.map{
+        case h *: tail => h
       }
     }
     val result = ctx.run(g)
@@ -50,4 +61,62 @@ class ArbitraryTupleSpec extends Spec {
       (123)
   }
 
+  "decode empty tuple" in {
+    inline def g = quote {
+      myRow2Query.map{
+        case (_, _) => EmptyTuple
+      }
+    }
+
+    val result = ctx.run(g)
+
+    result.extractor(Row(123, "St"), MirrorSession.default) mustEqual EmptyTuple
+  }
+
+  "construct tuple1" in {
+    inline def g = quote {
+      myRow1Query.map {
+        case (i, s) => i *: EmptyTuple
+      }
+    }
+
+    val result = ctx.run(g)
+
+    result.string mustEqual "SELECT x$1.int_field AS _1 FROM my_table x$1"
+    result.extractor(Row(123, "St"), MirrorSession.default) mustEqual
+      Tuple1(123)
+  }
+
+  "construct arbitrary tuple" in {
+    inline def g = quote {
+      myRow1Query.map {
+        case (i, s) => s *: i *: EmptyTuple
+      }
+    }
+    val result = ctx.run(g)
+
+    result.string mustEqual "SELECT x$1.string_field AS _1, x$1.int_field AS _2 FROM my_table x$1"
+    result.extractor(Row("St", 123), MirrorSession.default) mustEqual ("St", 123)
+
+  }
+
+  "constant arbitrary tuple" in {
+    inline def g = quote {
+      123 *: "St" *: true *: (3.14 *: EmptyTuple)
+    }
+    val result = ctx.run(g)
+    result.string mustEqual "SELECT 123 AS _1, 'St' AS _2, true AS _3, 3.14 AS _4"
+    result.info.executionType mustEqual Static
+    result.extractor(Row(123, "St", true, 3.14), MirrorSession.default) mustEqual (123, "St", true, 3.14)
+  }
+
+  "constant arbitrary tuple 1" in {
+    inline def g = quote {
+      (3.14 *: EmptyTuple)
+    }
+    val result = ctx.run(g)
+    result.string mustEqual "SELECT 3.14 AS _1"
+    result.info.executionType mustEqual Static
+    result.extractor(Row(3.14), MirrorSession.default) mustEqual Tuple1(3.14)
+  }
 }


### PR DESCRIPTION
Fixes #411

### Problem

To support Scala 3-style tuples, a few changes are needed:
- support at Quat level;
- decode to Scala 3 tuples;
- support pattern matching inside quotes;
- tuple construction (`*:`) inside quotes.

### Solution

So far Quat and decoding are implemented.

There are two variants of decoding:
- using recursive approach;
- using runtime.Tuples.fromIArray.

The latter might be more performant.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
