### PR TITLE
Widen Quats during type-checking

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/util/ProtoMessages.scala
+++ b/quill-sql/src/main/scala/io/getquill/util/ProtoMessages.scala
@@ -19,5 +19,6 @@ object ProtoMessages {
   private[getquill] def serializeAst = cache("quill.ast.serialize", variable("quill.ast.serialize", "quill_ast_serialize", "true").toBoolean)
   private[getquill] def maxQuatFields = cache("quill.quat.tooManyFields", variable("quill.quat.tooManyFields", "quill_quat_tooManyFields", "4").toInt)
   private[getquill] def errorDetail = cache("quill.error.detail", variable("quill.error.detail", "quill_error_detail", "false").toBoolean)
+  private[getquill] def aggressiveQuatChecking = cache("quill.quat.aggresive", variable("quill.quat.aggresive", "quill_quat_aggresive", "false").toBoolean)
 
 } // end ProtoMessages


### PR DESCRIPTION
Warning for QuatMaking `existsEncoderFor` non-existant decoder/encoder combo is too aggressive. Put it behind a switch. 

Also, widen the type first to help in collection summoning scenarios e.g. `concatMap(x => y)` on a `List[T]` which needs a CBF instance e.g. arrayUuidDecoder. Currently it tries summoning `y.type` i.e. the actual variable-type which is wrong. 
