### PR TITLE
Disable macro log do not print dynamic query detected

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/StaticTranslationMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/StaticTranslationMacro.scala
@@ -296,7 +296,7 @@ object StaticTranslationMacro {
         StaticState(query, primaryLifts, returnAction, idiom, secondaryLifts)(ast)
       }
 
-    if (tryStatic.isEmpty) {
+    if (tryStatic.isEmpty && io.getquill.util.Messages.debugEnabled) {
       val timeTaken = System.currentTimeMillis() - startTimeMs
       queryPrint(PrintType.Message(s"Dynamic Query Detected (compiled in ${timeTaken}ms)"), None)
     }


### PR DESCRIPTION
Fixes #470 

### Problem

`-Dquill.macro.log=false` doesn't silence the `Dynamic Query Detected ...` which become quite verbose when the project start to grow.

### Solution

Add the same condition to check the flag before printing the log above so it has parity with static query logs.

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
