### PR TITLE
Bump/Fix docker images and build steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ results.txt
 done.txt
 .history
 .jvmopts
+sqlline

--- a/build/Dockerfile-cassandra
+++ b/build/Dockerfile-cassandra
@@ -1,4 +1,4 @@
-FROM cassandra:3.11.11
+FROM cassandra:3.11.17
 MAINTAINER deusaquilus@gmail.com
 
 RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends default-jdk

--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -1,34 +1,34 @@
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER gustavo.amigo@gmail.com
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    mysql-client \
-    netcat \
+    default-mysql-client \
+    netcat-traditional \
     postgresql-client \
-    python \
     sqlite3 \
+    python2.7 \
     tar \
     apt-transport-https \
     locales \
     default-jre \
     apt-utils
 
-ADD https://repo1.maven.org/maven2/sqlline/sqlline/1.12.0/sqlline-1.12.0-jar-with-dependencies.jar /sqlline/sqlline.jar
-ADD https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar /sqlline/ojdbc.jar
-
 # RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
 # RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
 # RUN apt-get update && \
 # ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
 
+# Needed to run oracle scripts in setup_db_scripts/sqlline (does not use the one loaded in setup_databases.sh, perhaps setup_databases should use the one here)
+ADD https://repo1.maven.org/maven2/sqlline/sqlline/1.12.0/sqlline-1.12.0-jar-with-dependencies.jar /sqlline/sqlline.jar
+ADD https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar /sqlline/ojdbc.jar
 
 # Needed to get the apt-key add - to work
 RUN apt-get update && apt-get install -my wget gnupg
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
-RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 RUN apt update
 RUN ACCEPT_EULA=Y apt-get install -y mssql-tools
 
@@ -37,7 +37,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.11
+ENV CASSANDRA_VERSION 3.11.17
 ENV CASSANDRA_URL https://downloads.apache.org/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"

--- a/build/Dockerfile-sqlserver
+++ b/build/Dockerfile-sqlserver
@@ -1,6 +1,6 @@
 # Builds a ubuntu-based postgres image whose latency can be modified to be highe
 # for performance experimentation.
-FROM mcr.microsoft.com/mssql/server
+FROM mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
 USER root
 RUN apt-get update && \
     apt-get install iproute2 iputils-ping -y

--- a/build/m1/Dockerfile-setup
+++ b/build/m1/Dockerfile-setup
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.11
+ENV CASSANDRA_VERSION 3.11.17
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"
 RUN echo "Getting http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz"

--- a/build/setup_db_scripts.sh
+++ b/build/setup_db_scripts.sh
@@ -105,6 +105,8 @@ function setup_postgres() {
      host=$(get_host $1)
      echo "Waiting for Cassandra"
      until cqlsh $1 -e "describe cluster" &> /dev/null; do
+         echo "Tapping Cassandra Connection, this may show an error: $1 (host: ${host})"
+         cqlsh $1 -e "describe cluster" || true
          sleep 5;
      done
      echo "Connected to Cassandra"
@@ -116,6 +118,8 @@ function setup_sqlserver() {
     host=$(get_host $1)
     echo "Waiting for SqlServer"
     until /opt/mssql-tools/bin/sqlcmd -S $1 -U SA -P "QuillRocks!" -Q "select 1" &> /dev/null; do
+        echo "Tapping SqlServer Connection, this may show an error: $1 (host: ${host})"
+        /opt/mssql-tools/bin/sqlcmd -S $1 -U SA -P "QuillRocks!" -Q "select 1" || true
         sleep 5;
     done
     echo "Connected to SqlServer"

--- a/build/setup_local.sh
+++ b/build/setup_local.sh
@@ -5,7 +5,6 @@ set -e
 # import setup functions
 . /app/build/setup_db_scripts.sh
 
-
 time setup_mysql mysql
 time setup_postgres postgres
 time setup_cassandra cassandra $CASSANDRA_SCRIPT


### PR DESCRIPTION
Builds hanging e.g 
here: https://github.com/zio/zio-protoquill/actions/runs/11575950876
here: https://github.com/zio/zio-protoquill/actions/runs/11575527342

Were hanging. The actual quill-jdbc tests never started.
This like likely because the database-setup steps were not working and build.sh was stuck waiting for `wait_for_databases` to complete in `db_build()` or `bigdata_build()`. This fixes that and grabs new images.