### PR TITLE
Track latest SQL query string and ExecutionInfo in ZIO FiberRefs for Diagnostic

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/Diagnostic.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/Diagnostic.scala
@@ -1,0 +1,11 @@
+package io.getquill
+
+import zio.ZIO
+import zio.UIO
+import io.getquill.context.{ExecutionInfo, ZioQuillLog}
+
+def getLastExecutedQuery(): UIO[Option[String]] =
+  ZioQuillLog.latestSqlQuery.get
+
+def getLastExecutionInfo(): UIO[Option[ExecutionInfo]] =
+  ZioQuillLog.latestExecutionInfo.get

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
@@ -15,6 +15,8 @@ import javax.sql.DataSource
 import zio.Scope
 
 object ZioJdbc {
+  val SqlAnnotationKey = "quill.sql.latest"
+
   type QIO[T] = ZIO[DataSource, SQLException, T]
   type QStream[T] = ZStream[DataSource, SQLException, T]
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioJdbc.scala
@@ -15,8 +15,6 @@ import javax.sql.DataSource
 import zio.Scope
 
 object ZioJdbc {
-  val SqlAnnotationKey = "quill.sql.latest"
-
   type QIO[T] = ZIO[DataSource, SQLException, T]
   type QStream[T] = ZStream[DataSource, SQLException, T]
 

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioQuillLog.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/ZioQuillLog.scala
@@ -1,0 +1,17 @@
+package io.getquill.context
+
+import zio.FiberRef
+
+object ZioQuillLog {
+
+  val currentExecutionInfo: FiberRef[Option[ExecutionInfo]] =
+    FiberRef.unsafe.make[Option[ExecutionInfo]](None)(Unsafe.unsafe)
+
+  final class ExecutionInfoInformed(val executionInfo: () => ExecutionInfo) { self =>
+    def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      currentExecutionInfo.locallyWith(_ => Some(executionInfo()))(zio)
+  }
+
+  def withExecutionInfo(info: => ExecutionInfo): ExecutionInfoInformed =
+    new ExecutionInfoInformed(() => info)
+}

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
@@ -1,17 +1,17 @@
 package io.getquill.context.qzio
 
-import io.getquill.context.ZioJdbc._
+import io.getquill.context.ZioJdbc.*
 import io.getquill.context.jdbc.JdbcContextVerbExecute
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ ExecutionInfo, ContextVerbStream }
+import io.getquill.context.{ContextVerbStream, ExecutionInfo, ZioQuillLog}
 import io.getquill.util.ContextLogger
-import io.getquill._
-import zio.Exit.{ Failure, Success }
+import io.getquill.*
+import zio.Exit.{Failure, Success}
 import zio.ZIO.blocking
-import zio.stream.{ Stream, ZStream }
-import zio.{ Cause, Task, UIO, ZIO, StackTrace }
+import zio.stream.{Stream, ZStream}
+import zio.{Cause, StackTrace, Task, UIO, ZIO}
 
-import java.sql.{ Array => _, _ }
+import java.sql.{Array as _, *}
 import javax.sql.DataSource
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -59,31 +59,34 @@ abstract class ZioJdbcUnderlyingContext[+Dialect <: SqlIdiom, +Naming <: NamingS
   @targetName("runBatchActionReturningDefault")
   inline def run[I, T, A <: Action[I] & QAC[I, T]](inline quoted: Quoted[BatchAction[A]]): ZIO[Connection, SQLException, List[T]] = InternalApi.runBatchActionReturning(quoted, 1)
 
+  protected def annotate[R, E, A](zio: ZIO[R, E, A], sql: String, info: ExecutionInfo): ZIO[R, E, A] =
+    ZioQuillLog.withExecutionInfo(info)(ZIO.logAnnotate(ZioJdbc.SqlAnnotationKey, sql)(zio))
+
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
   override def executeAction(sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: Runner): QCIO[Long] =
-    super.executeAction(sql, prepare)(info, dc)
+    annotate(super.executeAction(sql, prepare)(info, dc), sql, info)
   override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): QCIO[List[T]] =
-    super.executeQuery(sql, prepare, extractor)(info, dc)
+    annotate(super.executeQuery(sql, prepare, extractor)(info, dc), sql, info)
   override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: Runner): QCIO[T] =
-    super.executeQuerySingle(sql, prepare, extractor)(info, dc)
+    annotate(super.executeQuerySingle(sql, prepare, extractor)(info, dc), sql, info)
   override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): QCIO[O] =
-    super.executeActionReturning(sql, prepare, extractor, returningBehavior)(info, dc)
+    annotate(super.executeActionReturning(sql, prepare, extractor, returningBehavior)(info, dc), sql, info)
   override def executeActionReturningMany[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: Runner): QCIO[List[O]] =
-    super.executeActionReturningMany(sql, prepare, extractor, returningBehavior)(info, dc)
+    annotate(super.executeActionReturningMany(sql, prepare, extractor, returningBehavior)(info, dc), sql, info)
   override def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): QCIO[List[Long]] =
-    super.executeBatchAction(groups)(info, dc)
+    annotate(super.executeBatchAction(groups)(info, dc), sql, info)
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: Runner): QCIO[List[T]] =
-    super.executeBatchActionReturning(groups, extractor)(info, dc)
+    annotate(super.executeBatchActionReturning(groups, extractor)(info, dc), sql, info)
   override def prepareQuery(sql: String, prepare: Prepare)(info: ExecutionInfo, dc: Runner): QCIO[PreparedStatement] =
-    super.prepareQuery(sql, prepare)(info, dc)
+    annotate(super.prepareQuery(sql, prepare)(info, dc), sql, info)
   override def prepareAction(sql: String, prepare: Prepare)(info: ExecutionInfo, dc: Runner): QCIO[PreparedStatement] =
-    super.prepareAction(sql, prepare)(info, dc)
+    annotate(super.prepareAction(sql, prepare)(info, dc), sql, info)
   override def prepareBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): QCIO[List[PreparedStatement]] =
-    super.prepareBatchAction(groups)(info, dc)
+    annotate(super.prepareBatchAction(groups)(info, dc), sql, info)
   override def translateQueryEndpoint[T](statement: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor, prettyPrint: Boolean = false)(info: ExecutionInfo, dc: Runner): QCIO[String] =
-    super.translateQueryEndpoint(statement, prepare, extractor, prettyPrint)(info, dc)
+    annotate(super.translateQueryEndpoint(statement, prepare, extractor, prettyPrint)(info, dc), sql, info)
   override def translateBatchQueryEndpoint(groups: List[BatchGroup], prettyPrint: Boolean = false)(info: ExecutionInfo, dc: Runner): QCIO[List[String]] =
-    super.translateBatchQueryEndpoint(groups, prettyPrint)(info, dc)
+    annotate(super.translateBatchQueryEndpoint(groups, prettyPrint)(info, dc), sql, info)
 
   /** ZIO Contexts do not managed DB connections so this is a no-op */
   override def close(): Unit = ()

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/DiagnosticDataSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/DiagnosticDataSpec.scala
@@ -1,0 +1,41 @@
+package io.getquill.postgres
+
+import io.getquill.*
+import io.getquill.ast.{Filter, ReturningGenerated}
+import io.getquill.context.AstSplicing
+import io.getquill.context.sql.ProductSpec
+
+class DiagnosticDataSpec extends ProductSpec with ZioSpec {
+
+  val context = testContextSplicing
+  import testContextSplicing.*
+
+  override def beforeAll() = {
+    super.beforeAll()
+    testContextSplicing.run(quote(query[Product].delete)).runSyncUnsafe()
+    ()
+  }
+
+  "Diagnostic data" - {
+    "Should expose last executed query" in {
+      val (insertQuery, selectQuery, insertInfo, selectInfo) = (for {
+        _ <- testContextSplicing.run {
+          liftQuery(productEntries).foreach(e => productInsert(e))
+        }
+        insertQuery <- getLastExecutedQuery()
+        insertInfo <- getLastExecutionInfo()
+
+        _ <- testContextSplicing.run(query[Product].filter(p => p.description == "Notebook"))
+        selectQuery <- getLastExecutedQuery()
+        selectInfo <- getLastExecutionInfo()
+
+      } yield (insertQuery, selectQuery, insertInfo, selectInfo)).runSyncUnsafe()
+
+      insertQuery.get mustBe "INSERT INTO Product (description,sku) VALUES (?, ?) RETURNING id"
+      selectQuery.get mustBe "SELECT p.id, p.description, p.sku FROM Product p WHERE p.description = 'Notebook'"
+
+      insertInfo.get.ast mustBe a[ReturningGenerated]
+      selectInfo.get.ast mustBe a[Filter]
+    }
+  }
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/package.scala
@@ -2,9 +2,11 @@ package io.getquill
 
 import io.getquill.context.qzio.ImplicitSyntax.Implicit
 import io.getquill.ZioSpec.runLayerUnsafe
+import io.getquill.context.AstSplicing
 import io.getquill.jdbczio.Quill
 
 package object postgres {
   val pool = runLayerUnsafe(Quill.DataSource.fromPrefix("testPostgresDB"))
   object testContext extends Quill.Postgres(Literal, pool) with TestEntities
+  object testContextSplicing extends Quill.Postgres(Literal, pool) with TestEntities with AstSplicing
 }

--- a/quill-sql/src/main/scala/io/getquill/context/QueryExecutionBatch.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/QueryExecutionBatch.scala
@@ -406,8 +406,15 @@ object QueryExecutionBatch {
                 )($traceConfigExpr)
               }
 
+              val spliceAsts = TypeRepr.of[Ctx] <:< TypeRepr.of[AstSplicing]
+              val executionInfo =
+                if (spliceAsts)
+                  '{ ExecutionInfo(ExecutionType.Static, ${ Lifter(state.ast) }, ${ Lifter.quat(topLevelQuat) }) }
+                else
+                  '{ ExecutionInfo(ExecutionType.Unknown, io.getquill.ast.NullValue, Quat.Unknown) }
+
               '{
-                $batchContextOperation.execute(ContextOperation.BatchArgument($batchGroups, $extractor, ExecutionInfo(ExecutionType.Static, ${ Lifter(state.ast) }, ${ Lifter.quat(topLevelQuat) }), None))
+                $batchContextOperation.execute(ContextOperation.BatchArgument($batchGroups, $extractor, $executionInfo, None))
               }
 
             case None =>


### PR DESCRIPTION
ZIO fiber-refs are a good way to keep around the latest SQL query string and ExecutionInfo. Adding that functionality.