### PR TITLE
fix sbt build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           distribution: temurin
           java-version: '17'
           check-latest: true
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Scala ${{ matrix.scala }} Building ${{ matrix.module }}
         env:
@@ -53,6 +55,8 @@ jobs:
           distribution: temurin
           java-version: '17'
           check-latest: true
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Apparently, [sbt was removed from Ubuntu 24](https://github.com/actions/setup-java/issues/712). This PR includes another step in the process to do the proper setup of the tool.

@getquill/maintainers
